### PR TITLE
Add ability to open AI dictionary entry from normal dict view

### DIFF
--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -60,6 +60,7 @@ local CONFIGURATION = {
         refresh_screen_after_displaying_results = true, -- Set to true to refresh the screen after displaying the results
         show_dictionary_button_in_main_popup = true, -- Set to true to show the dictionary button in the main popup
         dictionary_translate_to = "tr-TR", -- Set to the desired language code for the dictionary, nil to hide it
+        show_dictionary_button_in_dictionary_popup = false, -- Set to true to show the dictionary button in the dictionary popup
 
         -- Custom prompts for the AI (text = button text in the UI). system-prompt defaults to "You are a helpful assistant." if not set.
         prompts = {

--- a/main.lua
+++ b/main.lua
@@ -95,4 +95,21 @@ function Assistant:init()
   end
 end
 
+function Assistant:onDictButtonsReady(dict_popup, buttons)
+  if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.show_dictionary_button_in_dictionary_popup then
+    table.insert(buttons, 1, {{
+        id = "assistant_dictionary",
+        text = _("Dictionary").." (AI)",
+        font_bold = false,
+        callback = function()
+            NetworkMgr:runWhenOnline(function()
+                local showDictionaryDialog = require("dictdialog")
+                -- Pass the word from the dict_popup instead of the highlight instance:
+                showDictionaryDialog(self.ui, dict_popup.lookupword)
+            end)
+        end,
+    }})
+  end
+end
+
 return Assistant


### PR DESCRIPTION
### Motivation
When I read I often reach for the built-in dictionary feature but the built-in dictionaries sometimes do not have the word I am looking for.

I thought it would be convenient to have the option to make the Dictionary (AI) button appear on that dictionary screen (much like how the `Add to Vocabulary Builder` button can appear). I gated it behind a configuration parameter. This way I can invoke the AI dictionary when the built in dictionary sucks.

### What I did
1. Add a field to `features` called `show_dictionary_button_in_dictionary_popup` which when enabled makes the "Dictionary (AI) button appear in the normal dictionary view
2. Add the `onDictButtonsReady` method to the `Assistant` widget so that it adds the `Dictionary(AI)` button to the screen.

### Testing done
1. I loaded it up on my Kobo with the `show_dictionary_button_in_dictionary_popup` set to `true` and `false`. When set to true it properly appeared, when set to false it did not appear.