### PR TITLE
Add Ollama support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Assistant: AI Helper Plugin for KOReader
 
-A powerful plugin that lets you interact with AI language models (Claude, GPT-4, Gemini, DeepSeek etc.) while reading. Ask questions about text, get translations, summaries, explanations and more - all without leaving your book.
+A powerful plugin that lets you interact with AI language models (Claude, GPT-4, Gemini, DeepSeek, Ollama etc.) while reading. Ask questions about text, get translations, summaries, explanations and more - all without leaving your book.
 
 <small>Originally forked from deleted fork of  [zeeyado](https://github.com/zeeyado)  of [AskGPT](https://github.com/drewbaumann/askgpt),then modified using WindSurf.</small>
 
@@ -13,6 +13,7 @@ A powerful plugin that lets you interact with AI language models (Claude, GPT-4,
   - Gemini
   - OpenRouter: unified interface for LLMs
   - DeepSeek (not tested)
+  - Ollama
 - **Builtin Prompts**:
   - **Dictionary** : Get synonyms, context-aware dictionary explanation and example for the selected word. (thanks to [plateaukao](https://github.com/plateaukao/AskGP))
 - **Custom Prompts**: Create your own specialized AI helpers with their own quick actions and prompts
@@ -26,7 +27,7 @@ A powerful plugin that lets you interact with AI language models (Claude, GPT-4,
 ## Basic Requirements
 
 - [KoReader](https://github.com/koreader/koreader) installed on your device
-- API key from your preferred provider (Anthropic, OpenAI, Gemini, OpenRouter, DeepSeek, etc.)
+- API key from your preferred provider (Anthropic, OpenAI, Gemini, OpenRouter, DeepSeek, Ollama, etc.)
 
 ## Getting Started 
 
@@ -58,6 +59,9 @@ You'll need API keys for the AI service you want to use:
 1. Visit [platform.deepseek.com](https://platform.deepseek.com)
 2. Create an account or login to your existing account
 3. Go to "API Keys" section and create a new key
+
+**For Ollama**:
+1. Ollama doesn't use an API key. However, a placeholder API key value (ex: "ollama") is required.
 
 ### 2. Installation:
 #### Using The Latest Version:
@@ -103,7 +107,7 @@ The plugin supports extensive customization through `configuration.lua`. See the
 Configuration file has this structure:
 ```lua
 local CONFIGURATION = {
-    -- Choose your preferred AI provider: "anthropic", "openai", "gemini", "openrouter" or "deepseek"
+    -- Choose your preferred AI provider: "anthropic", "openai", "gemini", "openrouter", "deepseek" or "ollama"
     provider = "openai",
     
     -- Provider-specific settings (override defaults in api_handlers/defaults.lua)

--- a/api_handlers/ollama.lua
+++ b/api_handlers/ollama.lua
@@ -1,0 +1,53 @@
+local BaseHandler = require("api_handlers.base")
+local https = require("ssl.https")
+local ltn12 = require("ltn12")
+local json = require("json")
+
+local OllamaHandler = BaseHandler:new()
+
+function OllamaHandler:query(message_history, config)
+    local ollama_settings = config.provider_settings and config.provider_settings.ollama or {}
+
+    local required_settings = {"base_url", "model", "api_key"}
+    for _, setting in ipairs(required_settings) do
+      if not ollama_settings[setting] then
+        return "Error: Missing " .. setting .. " in configuration"
+      end
+    end
+
+    -- Ollama uses OpenAI-compatible API format
+    local requestBodyTable = {
+        model = ollama_settings.model,
+        messages = message_history,
+        stream = false
+    }
+
+    local requestBody = json.encode(requestBodyTable)
+    local responseBody = {}
+    local headers = {
+        ["Content-Type"] = "application/json",
+        ["Authorization"] = "Bearer " .. ollama_settings.api_key
+    }
+
+    local success, code = https.request({
+        url = ollama_settings.base_url,
+        method = "POST",
+        headers = headers,
+        source = ltn12.source.string(requestBody),
+        sink = ltn12.sink.table(responseBody)
+    })
+
+    if not success then
+        return "Error: Failed to connect to Ollama API - " .. tostring(code)
+    end
+
+    local response = json.decode(table.concat(responseBody))
+
+    if response and response.message then
+        return response.message.content
+    else
+        return "Error: Unexpected response format from API"
+    end
+end
+
+return OllamaHandler

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -1,7 +1,7 @@
 local CONFIGURATION = {
-    -- Choose your preferred AI provider: "anthropic", "openai", "gemini", "openrouter" or "deepseek"
+    -- Choose your preferred AI provider: "anthropic", "openai", "gemini", "openrouter", "deepseek" or "ollama"
     provider = "openai",
-    
+
     -- Provider-specific settings
     provider_settings = {
         anthropic = {
@@ -48,9 +48,15 @@ local CONFIGURATION = {
                 temperature = 0.7,
                 max_tokens = 4096
             }
-        }   
+        },
+        ollama = {
+            model = "your-preferred-model", -- model list: https://ollama.com/library
+            base_url = "your-ollama-api-endpoint", -- ex: "https://ollama.example.com/api/chat"
+            api_key = "ollama",
+            additional_parameters = { }
+        },
     },
-    
+
     -- Optional features, replace each "Turkish" with your desired language
     features = {
         hide_highlighted_text = false,  -- Set to true to hide the highlighted text at the top
@@ -79,14 +85,14 @@ local CONFIGURATION = {
                 order = 2,
                 system_prompt = "You are a helpful assistant that provides clear explanations.",
                 user_prompt = "Please simplify the following text in its own language: {highlight}",
-                show_on_main_popup = false -- Show the button in main popup    
+                show_on_main_popup = false -- Show the button in main popup
             },
             explain = {
                 text = "Explain",
                 order = 3,
                 system_prompt = "You are a helpful assistant that explains complex topics clearly and concisely. Break down concepts into simple terms.",
-                user_prompt = "Please explain the following text. Answer in Turkish: {highlight}", 
-                show_on_main_popup = false -- Show the button in main popup    
+                user_prompt = "Please explain the following text. Answer in Turkish: {highlight}",
+                show_on_main_popup = false -- Show the button in main popup
             },
             summarize = {
                 text = "Summarize",
@@ -100,7 +106,7 @@ local CONFIGURATION = {
                 order = 5,
                 system_prompt = "You are a historical context expert. Provide relevant historical background and connections.",
                 user_prompt = "Explain the historical context of this text. Answer in Turkish: {highlight}",
-                show_on_main_popup = false -- Show the button in main popup      
+                show_on_main_popup = false -- Show the button in main popup
             },
             key_points = {
                 text = "Key Points",

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -12,7 +12,7 @@ end
 -- Define handlers table with proper error handling
 local handlers = {}
 local function loadHandler(name)
-    local success, handler = pcall(function() 
+    local success, handler = pcall(function()
         return require("api_handlers." .. name)
     end)
     if success then
@@ -27,7 +27,8 @@ local provider_handlers = {
     openai = function() loadHandler("openai") end,
     deepseek = function() loadHandler("deepseek") end,
     gemini = function() loadHandler("gemini") end,
-    openrouter = function() loadHandler("openrouter") end
+    openrouter = function() loadHandler("openrouter") end,
+    ollama = function() loadHandler("ollama") end
 }
 
 if CONFIGURATION and CONFIGURATION.provider and provider_handlers[CONFIGURATION.provider] then
@@ -50,25 +51,25 @@ local function queryChatGPT(message_history)
 
     local provider = CONFIGURATION.provider
     local handler = handlers[provider]
-    
+
     if not handler then
         return "Error: Unsupported provider " .. provider
     end
-    
+
     -- Get API key for the selected provider
     CONFIGURATION.api_key = getApiKey(provider)
     if not CONFIGURATION.api_key then
         return "Error: No API key found for provider " .. provider .. ". Please check configuration.lua"
     end
-    
+
     local success, result = pcall(function()
         return handler:query(message_history, CONFIGURATION)
     end)
-    
+
     if not success then
         return "Error: " .. tostring(result)
     end
-    
+
     return result
 end
 


### PR DESCRIPTION
# Description

This PR adds support for using Ollama with the plugin. Ollama provides an convenient way to run AI models locally to test a varied range of models and minimize costs.

# Changes

- Added `OllamaHandler` and loaded it with `loadHandler` in `provider_handlers`.
- Added checks in `OllamaHandler` for `base_url` and `model` along with `api_key` as all of these are required and cannot have defaults.
- Updated `configuration.lua.sample` to have sample configuration for Ollama and added mentions of Ollama in `README.md` wherever applicable.

# Testing

- Successfully tested with multiple locally-hosted Ollama models.
- Verified compatibility with existing assistant features.
- Ensured no changes for users not using Ollama.