### PR TITLE
Adds Recap Dialog as a Built-in Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A powerful plugin that lets you interact with AI language models (Claude, GPT-4,
   - DeepSeek (not tested)
   - Ollama
 - **Builtin Prompts**:
-  - **Dictionary** : Get synonyms, context-aware dictionary explanation and example for the selected word. (thanks to [plateaukao](https://github.com/plateaukao/AskGP))
+  - **Dictionary** : Get synonyms, context-aware dictionary explanation and example for the selected word. (thanks to [plateaukao](https://github.com/plateaukao))
+  - **Recap** : Get a quick recap of a book when you open it, for books that haven't been opened in 28 hrs and <95% complete. (thanks to [jbhul](https://github.com/jbhul))
 - **Custom Prompts**: Create your own specialized AI helpers with their own quick actions and prompts
   - **Translation**: Instantly translate highlighted text to any language
   - **Quick Actions**: One-click buttons for common tasks like summarizing or explaining

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -77,6 +77,7 @@ local CONFIGURATION = {
         show_dictionary_button_in_main_popup = true, -- Set to true to show the dictionary button in the main popup
         dictionary_translate_to = "tr-TR", -- Set to the desired language code for the dictionary, nil to hide it
         show_dictionary_button_in_dictionary_popup = true, -- Set to true to show the Dictionary (AI) button in the dictionary popup
+        enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
 
         -- Custom prompts for the AI (text = button text in the UI). system-prompt defaults to "You are a helpful assistant." if not set.
         --You can use {author} and {title} variables in the user_prompt,

--- a/main.lua
+++ b/main.lua
@@ -63,6 +63,54 @@ function Assistant:init()
       }
     end)
   end
+  
+  -- Recap Feature
+  if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.enable_AI_recap then
+    local ReaderUI    = require("apps/reader/readerui")
+    local ConfirmBox  = require("ui/widget/confirmbox")
+    local UIManager   = require("ui/uimanager")
+    local T 		      = require("ffi/util").template
+    local lfs         = require("libs/libkoreader-lfs")   -- for file attributes
+    local DocSettings = require("docsettings")			      -- for document progress
+  
+    -- Save a reference to the original doShowReader method.
+    local original_doShowReader = ReaderUI.doShowReader
+  
+    -- Override the ReaderUI:doShowReader method.
+    function ReaderUI:doShowReader(file, provider, seamless)
+      -- Get file metadata; here we use the file's "access" attribute.
+      local attr = lfs.attributes(file)
+      local lastAccess = attr and attr.access or nil
+  
+      if lastAccess and lastAccess > 0 then -- Has been opened
+        local doc_settings = DocSettings:open(file)
+        local percent_finished = doc_settings:readSetting("percent_finished")
+        local timeDiffHours = (os.time() - lastAccess) / 3600.0
+  
+        if timeDiffHours >= 28 and percent_finished <= 0.95 then -- More than 28hrs since last open and less than 95% complete
+          -- Construct the message to display.
+          local doc_props = doc_settings:child("doc_props")
+          local title = doc_props:readSetting("title", "Unknown Title")
+          local authors = doc_props:readSetting("authors", "Unknown Author")
+          local message = string.format(_("Do you want an AI Recap?\nFor %s by %s.\nLast read %.0f hours ago."), title, authors, timeDiffHours) -- can add in percent_finished too
+  
+          -- Display the request popup using ConfirmBox.
+          UIManager:show(ConfirmBox:new{
+            text            = T(_(message)),
+            ok_text         = _("Yes"),
+            ok_callback     = function()
+              NetworkMgr:runWhenOnline(function()
+                local showRecapDialog = require("recapdialog")
+                showRecapDialog(self.ui, title, authors, percent_finished)
+              end)
+            end,
+            cancel_text     = _("No"),
+          })
+        end
+      end
+      original_doShowReader(self, file, provider, seamless)
+    end
+  end
 
   -- Add Custom buttons (ones with show_on_main_popup = true)
   if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.prompts then

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -1,0 +1,56 @@
+local InputDialog = require("ui/widget/inputdialog")
+local ChatGPTViewer = require("chatgptviewer")
+local UIManager = require("ui/uimanager")
+local TextBoxWidget = require("ui/widget/textboxwidget")
+local _ = require("gettext")
+local Event = require("ui/event")
+local queryChatGPT = require("gpt_query")
+local configuration = require("configuration")
+
+local function showRecapDialog(ui, title, author, progress_percent, message_history)
+	local formatted_progress_percent = string.format("%.2f", progress_percent * 100)
+    local message_history = message_history or {
+        {
+            role = "system",
+            content = "You are a book recap giver with entertaining tone and high quality detail with a focus on summarization. You also match the tone of the book provided.",
+        },
+    }
+    
+    local context_message = {
+        role = "user",
+		content = title .. " by " .. author .. " that has been " .. formatted_progress_percent .. "% read.\n" ..
+            "Given the above title and author of a book and the positional parameter, very briefly summarize the contents of the book prior with rich text formatting.\n" ..
+            "Above all else do not give any spoilers to the book, only consider prior content. Focus on the more recent content rather than a general summary to help the user pick up where they left off. \n" ..
+			"Match the tone and energy of the book, for example if the book is funny match that style of humor and tone, if it's an exciting fantasy novel show it, if it's a historical or sad book reflect that.\n" ..
+			"Use text bolding to emphasize names and locations. Use italics to emphasize major plot points. No emojis or symbols.\n" ..
+            "Answer this whole response in ".. configuration.features.dictionary_translate_to .." language.\n" ..
+            "only show the replies, do not give a description."
+    }
+    table.insert(message_history, context_message)
+
+    local answer = queryChatGPT(message_history)
+    local function createResultText(answer)
+        local result_text = 
+            TextBoxWidget.PTF_HEADER .. 
+            TextBoxWidget.PTF_BOLD_START .. title .. TextBoxWidget.PTF_BOLD_END .. " by " .. author .. " is " .. formatted_progress_percent .. "% complete.\n\n" ..
+            answer 
+        return result_text
+    end
+
+    local result_text = createResultText(answer)
+    local chatgpt_viewer = nil
+
+    chatgpt_viewer = ChatGPTViewer:new {
+        ui = ui,
+        title = _("Recap"),
+        text = result_text,
+        showAskQuestion = false
+    }
+
+    UIManager:show(chatgpt_viewer)
+    if configuration and configuration.features and configuration.features.refresh_screen_after_displaying_results then
+        UIManager:setDirty(nil, "full")
+    end
+end
+
+return showRecapDialog


### PR DESCRIPTION
Adds an optional prompt for books on open to give the user an AI generated recap of the book so far to help them pick up where they left off. Only prompts for books that have already been opened but not read in 28 hours and are less than 95% complete. Updates main, configuration, and ReadMe in kind.

Open to prompt, message string, time since open cutoff, and percent_finished cutoff tweaks (or whatever else). Can also add the time cutoff to config. Can also add a percent_finished cutoff for the start, if the book is less than 5% for example.