### PR TITLE
DeepSeek: If there's more information about the API error, show it in the message

### DIFF
--- a/api_handlers/deepseek.lua
+++ b/api_handlers/deepseek.lua
@@ -121,8 +121,10 @@ function DeepSeekHandler:query(message_history, config)
     
     if parsed and parsed.choices and parsed.choices[1] and parsed.choices[1].message then
         return parsed.choices[1].message.content
+    elseif parsed and parsed.error then
+	    return "DeepSeek API Error: [" .. parsed.error.code .. "]: " .. parsed.error.message
     else
-        return "Error: Unexpected response format from API"
+        return "DeepSeek API Error: Unexpected response format from API: " .. response
     end
 end
 


### PR DESCRIPTION
This is just so it's easier to tell why the API calls are failing. For example, it can be due to lack of funds.