### PR TITLE
add groq support

### DIFF
--- a/api_handlers/groq.lua
+++ b/api_handlers/groq.lua
@@ -1,0 +1,125 @@
+local BaseHandler = require("api_handlers.base")
+local https = require("ssl.https")
+local ltn12 = require("ltn12")
+local json = require("json")
+local logger = require("logger")
+local Device = require("device")
+
+local groqHandler = BaseHandler:new()
+
+function groqHandler:makeRequest(url, headers, body)
+    logger.dbg("Attempting groq API request:", {
+        url = url,
+        headers = headers and "present" or "missing",
+        body_length = #body
+    })
+    
+    -- Try using curl first (more reliable on Kindle)
+    if Device:isKindle() then
+        local tmp_request = "/tmp/groq_request.json"
+        local tmp_response = "/tmp/groq_response.json"
+        
+        -- Write request body
+        local f = io.open(tmp_request, "w")
+        if f then
+            f:write(body)
+            f:close()
+        end
+        
+        -- Construct curl command with proper headers
+        local header_args = ""
+        for k, v in pairs(headers) do
+            header_args = header_args .. string.format(' -H "%s: %s"', k, v)
+        end
+        
+        local curl_cmd = string.format(
+            'curl -k -s -X POST%s --connect-timeout 30 --retry 2 --retry-delay 3 '..
+            '--data-binary @%s "%s" -o %s',
+            header_args, tmp_request, url, tmp_response
+        )
+        
+        logger.dbg("Executing curl command:", curl_cmd:gsub(headers["Authorization"], "Bearer ***")) -- Hide API key in logs
+        local curl_result = os.execute(curl_cmd)
+        logger.dbg("Curl execution result:", curl_result)
+        
+        -- Read response
+        local response = nil
+        f = io.open(tmp_response, "r")
+        if f then
+            response = f:read("*all")
+            f:close()
+            logger.dbg("Curl response length:", #response)
+        else
+            logger.warn("Failed to read curl response file")
+        end
+        
+        -- Cleanup
+        os.remove(tmp_request)
+        os.remove(tmp_response)
+        
+        if response then
+            return true, 200, response
+        end
+    end
+    
+    -- Fallback to standard HTTPS if curl fails or not on Kindle
+    logger.dbg("Attempting HTTPS fallback request")
+    local response = {}
+    local status, code, responseHeaders = https.request{
+        url = url,
+        method = "POST",
+        headers = headers,
+        source = ltn12.source.string(body),
+        sink = ltn12.sink.table(response),
+        protocol = "tlsv1_2",
+        verify = "none", -- Disable SSL verification for Kindle
+        timeout = 30
+    }
+    
+    return status, code, table.concat(response)
+end
+
+function groqHandler:query(message_history, config)
+    local groq_settings = config.provider_settings and config.provider_settings.groq
+
+    -- Remove is_context from body, which causes an error in groq API
+    -- Need to clone the history so that we don't affect the actual message history which gets displayed
+    local cloned_history = {}
+
+    for i, message in ipairs(message_history) do
+      local new_message = {}
+      for k, v in pairs(message) do
+        new_message[k] = v
+      end
+
+      -- Remove the is_context field in the clone
+      new_message.is_context = nil
+
+      cloned_history[i] = new_message
+    end
+    
+    local requestBodyTable = {
+        model = groq_settings.model,
+        messages = cloned_history,
+        max_tokens = groq_settings.max_tokens
+    }
+
+    local requestBody = json.encode(requestBodyTable)
+    local headers = {
+        ["Content-Type"] = "application/json",
+        ["Authorization"] = "Bearer " .. (groq_settings.api_key)
+    }
+
+    local status, code, response = self:makeRequest(groq_settings.base_url, headers, requestBody)
+
+    if status and code == 200 then
+        local success, responseData = pcall(json.decode, response)
+        if success and responseData and responseData.choices and responseData.choices[1] then
+            return responseData.choices[1].message.content
+        end
+    end
+    
+    return nil, "Error: " .. (code or "unknown") .. " - " .. response
+end
+
+return groqHandler

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -64,6 +64,12 @@ local CONFIGURATION = {
                 max_tokens = 4096
             }
         },
+        groq = {
+            model = "llama-3.3-70b-versatile", -- model list: https://console.groq.com/docs/models
+            base_url = "https://api.groq.com/openai/v1/chat/completions",
+            api_key = "your-groq-api-key",
+            additional_parameters = { }
+        },
     },
 
     -- Optional features, replace each "Turkish" with your desired language

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -29,7 +29,8 @@ local provider_handlers = {
     gemini = function() loadHandler("gemini") end,
     openrouter = function() loadHandler("openrouter") end,
     ollama = function() loadHandler("ollama") end,
-    mistral = function() loadHandler("mistral") end
+    mistral = function() loadHandler("mistral") end,
+    groq = function() loadHandler("groq") end
 }
 
 if CONFIGURATION and CONFIGURATION.provider and provider_handlers[CONFIGURATION.provider] then


### PR DESCRIPTION
groq platform provides really **fast** hardware for LLM models, it would be quite good experiance when using in KOReader as it's without streaming display.

like Mistral API, the `is_context` attr needs to be removed.