### PR TITLE
add option for markdown -> HTML conversion and rendering

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -779,7 +779,12 @@ function ChatGPTViewer:update(new_text)
     
     -- Always scroll to the new text except first time
     if not first_time then
-      self.scroll_text_w:scrollToBottom()
+      if self.render_markdown then
+        -- If rendering in a ScrollHtmlWidget, use scrollToRatio
+        self.scroll_text_w:scrollToRatio(1)
+      else
+        self.scroll_text_w:scrollToBottom()
+      end
     end
 
     -- Refresh the screen after displaying the results

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -38,7 +38,8 @@ local InfoMessage = require("ui/widget/infomessage")
 local Screen = Device.screen
 local MD = require("apps/filemanager/lib/md")
 
--- https://github.com/koreader/koreader/blob/14ddbbfcd3e9b2426e8fd6fe2c244e6561355ed3/frontend/ui/widget/dictquicklookup.lua#L807-L826
+-- Undo default margins and padding in ScrollHtmlWidget.
+-- Based on ui/widget/dictquicklookup.
 local VIEWER_CSS = [[
 @page {
     margin: 0;
@@ -373,7 +374,6 @@ function ChatGPTViewer:init()
 
   if self.render_markdown then
     -- Convert Markdown to HTML and render in a ScrollHtmlWidget
-    -- https://github.com/koreader/koreader/blob/20fee6536d2621e66c5fd17b971f616924ddd537/frontend/apps/filemanager/filemanagerconverter.lua#L41-L54
     local html_body, err = MD(self.text, {})
     if err then
       logger.warn("ChatGPTViewer: could not generate HTML", err)
@@ -742,7 +742,6 @@ function ChatGPTViewer:update(new_text)
 
     if self.render_markdown then
       -- Convert Markdown to HTML and recreate the ScrollHtmlWidget with the new text
-      -- https://github.com/koreader/koreader/blob/20fee6536d2621e66c5fd17b971f616924ddd537/frontend/apps/filemanager/filemanagerconverter.lua#L41-L54
       local html_body, err = MD(self.text, {})
       if err then
         logger.warn("ChatGPTViewer: could not generate HTML", err)

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -92,6 +92,7 @@ local CONFIGURATION = {
         dictionary_translate_to = "tr-TR", -- Set to the desired language code for the dictionary, nil to hide it
         show_dictionary_button_in_dictionary_popup = true, -- Set to true to show the Dictionary (AI) button in the dictionary popup
         enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
+        render_markdown = false, -- Set to true to render markdown in the AI responses
 
         -- Custom prompts for the AI (text = button text in the UI). system-prompt defaults to "You are a helpful assistant." if not set.
         --You can use {author} and {title} variables in the user_prompt,

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -133,7 +133,7 @@ local function createResultText(highlightedText, message_history, previous_text,
 end
 
 -- Helper function to create and show ChatGPT viewer
-local function createAndShowViewer(ui, highlightedText, message_history, title, show_highlighted_text)
+local function createAndShowViewer(ui, highlightedText, message_history, title, render_markdown, show_highlighted_text)
   show_highlighted_text = show_highlighted_text == nil and true or show_highlighted_text
   local result_text = createResultText(highlightedText, message_history, nil, show_highlighted_text)
   
@@ -155,7 +155,8 @@ local function createAndShowViewer(ui, highlightedText, message_history, title, 
       end)
     end,
     highlighted_text = highlightedText,
-    message_history = message_history
+    message_history = message_history,
+    render_markdown = render_markdown,
   }
   
   UIManager:show(chatgpt_viewer)
@@ -226,6 +227,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
     UIManager:scheduleIn(0.1, function()
       local message_history, err
       local title
+      local render_markdown = CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.render_markdown
 
       message_history, err = handlePredefinedPrompt(direct_prompt, highlightedText, ui)
       if err then
@@ -239,7 +241,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
         return
       end
 
-      createAndShowViewer(ui, highlightedText, message_history, title)
+      createAndShowViewer(ui, highlightedText, message_history, title, render_markdown)
     end)
     return
   end
@@ -250,6 +252,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
     role = "system",
     content = CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.system_prompt or "You are a helpful assistant for reading comprehension."
   }}
+  local render_markdown = CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.render_markdown
 
   -- Create button rows (3 buttons per row)
   local button_rows = {}
@@ -292,7 +295,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
             input_dialog = nil
           end
           
-          createAndShowViewer(ui, highlightedText, message_history, "Assistant")
+          createAndShowViewer(ui, highlightedText, message_history, "Assistant", render_markdown)
         end)
       end
     }
@@ -347,7 +350,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
               UIManager:show(InfoMessage:new{text = _("Error: " .. err)})
               return
             end
-            createAndShowViewer(ui, highlightedText, message_history, prompt.text)
+            createAndShowViewer(ui, highlightedText, message_history, prompt.text, render_markdown)
           end)
         end
       })


### PR DESCRIPTION
Current behavior would be unchanged -- displays raw plaintext from the configured LLM
<img src="https://github.com/user-attachments/assets/00d04a15-f437-482c-9b75-95fe0580817e" width="480" />


Setting `render_markdown = true` treats the LLM response as markdown. The internal `apps/filemanager/lib/md` is used to convert markdown -> HTML, and the HTML is rendered in a `ScrollHtmlWidget` instead of `ScrollTextWidget`.
<img src="https://github.com/user-attachments/assets/50850f31-53af-4c49-b22e-81e18ec2278c" width="480" />

