### PR TITLE
expose thinkingBudget option for gemini

### DIFF
--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -28,7 +28,9 @@ local CONFIGURATION = {
             api_key = "your-gemini-api-key",
             additional_parameters = {
                 temperature = 0.7,
-                max_tokens = 4096
+                max_tokens = 4096,
+                -- Set to 0 to disable thinking. Recommended for gemini-2.5-* and newer, where thinking is enabled by default.
+                thinking_budget = nil
             }
         },
         openrouter = {


### PR DESCRIPTION
Gemini 2.5 models enable thinking by default. This results in several seconds of extra latency before a response appears. For simple explain or translate prompts, thinking is likely overkill.

This PR allows setting `generationConfig.thinkingConfig.thinkingBudget` in the request to Gemini. By default this is `nil` (unset) and will use Google's defaults. Setting to `0` disables thinking. Other values are probably less useful, but might as well be configurable.

https://ai.google.dev/gemini-api/docs/thinking
> Note: Thinking is enabled by default for the 2.5 series models. Read the section on [setting a thinking budget](https://ai.google.dev/gemini-api/docs/thinking#set-budget) for details and configuration.