### PR TITLE
Add markdown_font_size option

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -79,6 +79,7 @@ local ChatGPTViewer = InputContainer:extend {
   auto_para_direction = true,
   alignment_strict = false,
   render_markdown = true, -- converts markdown to HTML and displays the HTML
+  markdown_font_size = 20,
 
   title_face = nil,               -- use default from TitleBar
   title_multilines = nil,         -- see TitleBar for details
@@ -393,6 +394,7 @@ function ChatGPTViewer:init()
     self.scroll_text_w = ScrollHtmlWidget:new {
       html_body = html_body,
       css = VIEWER_CSS,
+      default_font_size = Screen:scaleBySize(self.markdown_font_size),
       width = self.width - 2 * self.text_padding - 2 * self.text_margin,
       height = textw_height - 2 * self.text_padding - 2 * self.text_margin,
       dialog = self,
@@ -761,6 +763,7 @@ function ChatGPTViewer:update(new_text)
       self.scroll_text_w = ScrollHtmlWidget:new {
         html_body = html_body,
         css = VIEWER_CSS,
+        default_font_size = Screen:scaleBySize(self.markdown_font_size),
         width = self.width - 2 * self.text_padding - 2 * self.text_margin,
         height = self.textw:getSize().h - 2 * self.text_padding - 2 * self.text_margin,
         dialog = self,

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -95,6 +95,7 @@ local CONFIGURATION = {
         show_dictionary_button_in_dictionary_popup = true, -- Set to true to show the Dictionary (AI) button in the dictionary popup
         enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
         render_markdown = true, -- Set to true to render markdown in the AI responses
+        markdown_font_size = 20, -- Default normal text font size of rendered markdown.
 
         -- Custom prompts for the AI (text = button text in the UI). system-prompt defaults to "You are a helpful assistant." if not set.
         --You can use {author} and {title} variables in the user_prompt,
@@ -139,7 +140,7 @@ local CONFIGURATION = {
                 text = "Key Points",
                 order = 6,
                 system_prompt = "You are a key points expert. Provide a concise list of key points from the text.",
-                user_prompt = "Please provide a concise list of key points from the following text. Answer in Turkish: {highlight}",
+                user_prompt = "Please provide a concise list in markdown format of key points from the following text. Answer in Turkish: {highlight}",
                 show_on_main_popup = false -- Show the button in main popup
             },
             ELI5 = {


### PR DESCRIPTION
1. add `markdown_font_size` in the configuration file, define a normal text size for the markdown result.
2. the new added option is optional, if user use an old configuration without the option, script uses a default value without crashing.
3. refactor the`createAndShowViewer` function, removed  `render_markdown`  argument,  without reading `CONFIGURATION.features.render_markdown` in many places.
4. optimize the output response for better markdown compatible format. now `⮞ Assistant:`  `⮞ User` will show in a `h3` heading line.