### PR TITLE
Standalone Ask and Recap shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A powerful plugin that lets you interact with AI language models (Claude, GPT-4,
   - Ollama
 - **Builtin Prompts**:
   - **Dictionary** : Get synonyms, context-aware dictionary explanation and example for the selected word. (thanks to [plateaukao](https://github.com/plateaukao))
-  - **Recap** : Get a quick recap of a book when you open it, for books that haven't been opened in 28 hrs and <95% complete. (thanks to [jbhul](https://github.com/jbhul))
+  - **Recap** : Get a quick recap of a book when you open it, for books that haven't been opened in 28 hrs and <95% complete. Also available via shortcut/gesture for on-demand access. Fully configurable prompts. (thanks to [jbhul](https://github.com/jbhul))
 - **Custom Prompts**: Create your own specialized AI helpers with their own quick actions and prompts
   - **Translation**: Instantly translate highlighted text to any language
   - **Quick Actions**: One-click buttons for common tasks like summarizing or explaining
@@ -135,6 +135,13 @@ local CONFIGURATION = {
         refresh_screen_after_displaying_results = true, -- Set to true to refresh the screen after displaying the results
         show_dictionary_button_in_main_popup = true, -- Set to true to show the dictionary button in the main popup
         dictionary_translate_to = "tr-TR", -- Set to the desired language code for the dictionary, nil to hide it
+
+        -- AI Recap configuration (optional)
+        recap_config = {
+            system_prompt = "You are a book recap giver with entertaining tone...", -- Custom system prompt for recap
+            user_prompt = "{title} by {author} that has been {progress}% read...", -- Custom user prompt template with variables
+            language = "tr-TR" -- Language for recap responses, uses dictionary_translate_to as fallback
+        },
 
         -- Custom prompts for the AI (text = button text in the UI). system-prompt defaults to "You are a helpful assistant." if not set.
         prompts = {

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -96,6 +96,19 @@ local CONFIGURATION = {
         enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
         render_markdown = true, -- Set to true to render markdown in the AI responses
 
+        -- AI Recap configuration
+        recap_config = {
+            system_prompt = "You are a book recap giver with entertaining tone and high quality detail with a focus on summarization. You also match the tone of the book provided.",
+            user_prompt = "{title} by {author} that has been {progress}% read.\n" ..
+                         "Given the above title and author of a book and the positional parameter, very briefly summarize the contents of the book prior with rich text formatting.\n" ..
+                         "Above all else do not give any spoilers to the book, only consider prior content. Focus on the more recent content rather than a general summary to help the user pick up where they left off.\n" ..
+                         "Match the tone and energy of the book, for example if the book is funny match that style of humor and tone, if it's an exciting fantasy novel show it, if it's a historical or sad book reflect that.\n" ..
+                         "Use text bolding to emphasize names and locations. Use italics to emphasize major plot points. No emojis or symbols.\n" ..
+                         "Answer this whole response in {language} language.\n" ..
+                         "only show the replies, do not give a description.",
+            language = "tr-TR" -- Language for recap responses, uses dictionary_translate_to as fallback
+        },
+
         -- Custom prompts for the AI (text = button text in the UI). system-prompt defaults to "You are a helpful assistant." if not set.
         --You can use {author} and {title} variables in the user_prompt,
         --and {highlight} variable for the highlighted text otherwise its appended to the user_prompt automatically.

--- a/main.lua
+++ b/main.lua
@@ -34,6 +34,16 @@ function Assistant:onDispatcherRegisterActions()
     separator = true
   })
   
+  -- Register AI recap action
+  if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.enable_AI_recap then
+    Dispatcher:registerAction("ai_recap", {
+      category = "none", 
+      event = "AskAIRecap", 
+      title = _("AI Recap"), 
+      general = true,
+    })
+  end
+  
   -- Note: Dictionary and custom prompt actions are not registered as they require highlighted text
   -- They remain available through the highlight dialog and main AI dialog
 end
@@ -204,6 +214,46 @@ function Assistant:onAskAIQuestion()
     end
     -- Show dialog without requiring highlighted text
     showChatGPTDialog(self.ui, nil)
+  end)
+  return true
+end
+
+function Assistant:onAskAIRecap()
+  if not CONFIGURATION then
+    local UIManager = require("ui/uimanager")
+    local InfoMessage = require("ui/widget/infomessage")
+    UIManager:show(InfoMessage:new{
+      text = _("Configuration not found. Please set up configuration.lua first.")
+    })
+    return true
+  end
+  
+  if not CONFIGURATION.features or not CONFIGURATION.features.enable_AI_recap then
+    local UIManager = require("ui/uimanager")
+    local InfoMessage = require("ui/widget/infomessage")
+    UIManager:show(InfoMessage:new{
+      text = _("AI Recap feature is not enabled in configuration.")
+    })
+    return true
+  end
+  
+  NetworkMgr:runWhenOnline(function()
+    if not updateMessageShown then
+      UpdateChecker.checkForUpdates()
+      updateMessageShown = true
+    end
+    
+    -- Get current book information
+    local DocSettings = require("docsettings")
+    local doc_settings = DocSettings:open(self.ui.document.file)
+    local percent_finished = doc_settings:readSetting("percent_finished") or 0
+    local doc_props = doc_settings:child("doc_props")
+    local title = doc_props:readSetting("title") or self.ui.document:getProps().title or _("Unknown Title")
+    local authors = doc_props:readSetting("authors") or self.ui.document:getProps().authors or _("Unknown Author")
+    
+    -- Show recap dialog
+    local showRecapDialog = require("recapdialog")
+    showRecapDialog(self.ui, title, authors, percent_finished)
   end)
   return true
 end

--- a/main.lua
+++ b/main.lua
@@ -30,8 +30,7 @@ function Assistant:onDispatcherRegisterActions()
     category = "none", 
     event = "AskAIQuestion", 
     title = _("Ask AI Question"), 
-    general = true,
-    separator = true
+    general = true
   })
   
   -- Register AI recap action
@@ -41,6 +40,7 @@ function Assistant:onDispatcherRegisterActions()
       event = "AskAIRecap", 
       title = _("AI Recap"), 
       general = true,
+      separator = true
     })
   end
   

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,7 @@
 local Device = require("device")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local NetworkMgr = require("ui/network/manager")
+local Dispatcher = require("dispatcher")
 local _ = require("gettext")
 
 local showChatGPTDialog = require("dialogs")
@@ -23,7 +24,24 @@ end
 -- Flag to ensure the update message is shown only once per session
 local updateMessageShown = false
 
+function Assistant:onDispatcherRegisterActions()
+  -- Register main AI ask action
+  Dispatcher:registerAction("ai_ask_question", {
+    category = "none", 
+    event = "AskAIQuestion", 
+    title = _("Ask AI Question"), 
+    general = true,
+    separator = true
+  })
+  
+  -- Note: Dictionary and custom prompt actions are not registered as they require highlighted text
+  -- They remain available through the highlight dialog and main AI dialog
+end
+
 function Assistant:init()
+  -- Register actions with dispatcher for gesture assignment
+  self:onDispatcherRegisterActions()
+  
   -- Assistant button
   self.ui.highlight:addToHighlightDialog("assistant", function(_reader_highlight_instance)
     return {
@@ -166,6 +184,28 @@ function Assistant:onDictButtonsReady(dict_popup, buttons)
         end,
     }})
   end
+end
+
+-- Event handlers for gesture-triggered actions
+function Assistant:onAskAIQuestion()
+  if not CONFIGURATION then
+    local UIManager = require("ui/uimanager")
+    local InfoMessage = require("ui/widget/infomessage")
+    UIManager:show(InfoMessage:new{
+      text = _("Configuration not found. Please set up configuration.lua first.")
+    })
+    return true
+  end
+  
+  NetworkMgr:runWhenOnline(function()
+    if not updateMessageShown then
+      UpdateChecker.checkForUpdates()
+      updateMessageShown = true
+    end
+    -- Show dialog without requiring highlighted text
+    showChatGPTDialog(self.ui, nil)
+  end)
+  return true
 end
 
 return Assistant

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -12,7 +12,7 @@ local function showRecapDialog(ui, title, author, progress_percent, message_hist
     local message_history = message_history or {
         {
             role = "system",
-            content = "You are a book recap giver with entertaining tone and high quality detail with a focus on summarization. You also match the tone of the book provided.",
+            content = "You are a professional book reviewer with high quality to detail and a focus on summarization. You also match the tone of the book provided.",
         },
     }
     
@@ -23,7 +23,7 @@ local function showRecapDialog(ui, title, author, progress_percent, message_hist
             "Above all else do not give any spoilers to the book, only consider prior content. Focus on the more recent content rather than a general summary to help the user pick up where they left off. \n" ..
 			"Match the tone and energy of the book, for example if the book is funny match that style of humor and tone, if it's an exciting fantasy novel show it, if it's a historical or sad book reflect that.\n" ..
 			"Use text bolding to emphasize names and locations. Use italics to emphasize major plot points. No emojis or symbols.\n" ..
-            "Answer this whole response in ".. configuration.features.dictionary_translate_to .." language.\n" ..
+            "Answer this whole response in ".. configuration.features.dictionary_translate_to .." language, ensuring the language used is appropriate and avoids overly casual or stereotypical expressions.\n" ..
             "only show the replies, do not give a description."
     }
     table.insert(message_history, context_message)

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -9,22 +9,30 @@ local configuration = require("configuration")
 
 local function showRecapDialog(ui, title, author, progress_percent, message_history)
 	local formatted_progress_percent = string.format("%.2f", progress_percent * 100)
+    
+    -- Get recap configuration with fallbacks
+    local recap_config = configuration.features and configuration.features.recap_config or {}
+    local system_prompt = recap_config.system_prompt or "You are a book recap giver with entertaining tone and high quality detail with a focus on summarization. You also match the tone of the book provided."
+    local user_prompt_template = recap_config.user_prompt or "{title} by {author} that has been {progress}% read.\nGiven the above title and author of a book and the positional parameter, very briefly summarize the contents of the book prior with rich text formatting.\nAbove all else do not give any spoilers to the book, only consider prior content. Focus on the more recent content rather than a general summary to help the user pick up where they left off.\nMatch the tone and energy of the book, for example if the book is funny match that style of humor and tone, if it's an exciting fantasy novel show it, if it's a historical or sad book reflect that.\nUse text bolding to emphasize names and locations. Use italics to emphasize major plot points. No emojis or symbols.\nAnswer this whole response in {language} language.\nonly show the replies, do not give a description."
+    local language = recap_config.language or (configuration.features and configuration.features.dictionary_translate_to) or "English"
+    
     local message_history = message_history or {
         {
             role = "system",
-            content = "You are a professional book reviewer with high quality to detail and a focus on summarization. You also match the tone of the book provided.",
+            content = system_prompt,
         },
     }
     
+    -- Format the user prompt with variables
+    local user_content = user_prompt_template
+        :gsub("{title}", title)
+        :gsub("{author}", author)
+        :gsub("{progress}", formatted_progress_percent)
+        :gsub("{language}", language)
+    
     local context_message = {
         role = "user",
-		content = title .. " by " .. author .. " that has been " .. formatted_progress_percent .. "% read.\n" ..
-            "Given the above title and author of a book and the positional parameter, very briefly summarize the contents of the book prior with rich text formatting.\n" ..
-            "Above all else do not give any spoilers to the book, only consider prior content. Focus on the more recent content rather than a general summary to help the user pick up where they left off. \n" ..
-			"Match the tone and energy of the book, for example if the book is funny match that style of humor and tone, if it's an exciting fantasy novel show it, if it's a historical or sad book reflect that.\n" ..
-			"Use text bolding to emphasize names and locations. Use italics to emphasize major plot points. No emojis or symbols.\n" ..
-            "Answer this whole response in ".. configuration.features.dictionary_translate_to .." language, ensuring the language used is appropriate and avoids overly casual or stereotypical expressions.\n" ..
-            "only show the replies, do not give a description."
+		content = user_content
     }
     table.insert(message_history, context_message)
 


### PR DESCRIPTION
This PR allows the Ask and Recap options to be triggered by custom shortcuts. This enables the user to ask anything about the book without needing to highlight text first. It also enables triggering the recap at any time.

I also changed the recap prompt to be configurable, with a fallback to the previous prompt.