### PR TITLE
add option updater_disabled

### DIFF
--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -96,6 +96,7 @@ local CONFIGURATION = {
         enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
         render_markdown = true, -- Set to true to render markdown in the AI responses
         markdown_font_size = 20, -- Default normal text font size of rendered markdown.
+        updater_disabled = false, -- Set to true to disable update check.
 
         -- AI Recap configuration
         recap_config = {

--- a/update_checker.lua
+++ b/update_checker.lua
@@ -6,6 +6,12 @@ local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 
 local function checkForUpdates()
+
+  local success, CONFIGURATION = pcall(function() return require("configuration") end)
+  if success and CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.updater_disabled then
+    return
+  end
+
   local response_body = {}
   local _, code = http.request {
     url = "https://api.github.com/repos/omer-faruq/assistant.koplugin/releases/latest",


### PR DESCRIPTION
In some network, accessbility to github api is slow or blocked, cause the plugin takes time to load.

This PR adds an feature option `updater_disabled` to disable the checking.