### PR TITLE
Adding loading message in recap / dict / updater

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -293,6 +293,7 @@ function ChatGPTViewer:init()
           if self.text and self.text ~= "" then
               Device.input.setClipboardText(self.text)
               UIManager:show(InfoMessage:new{
+                  icon = "info",
                   text = _("Text copied to clipboard"),
                   timeout = 3,
               })
@@ -312,6 +313,7 @@ function ChatGPTViewer:init()
               local ui = self.ui
               if not ui or not ui.highlight then
                   UIManager:show(InfoMessage:new{
+                      icon = "cancel",
                       text = _("Highlight functionality not available"),
                       timeout = 2
                   })
@@ -320,6 +322,7 @@ function ChatGPTViewer:init()
               
               if not self.text or self.text == "" then
                   UIManager:show(InfoMessage:new{
+                      icon = "cancel",
                       text = _("No text to add as note"),
                       timeout = 2
                   })
@@ -348,6 +351,7 @@ function ChatGPTViewer:init()
                             
               if note_text == "" then
                   UIManager:show(InfoMessage:new{
+                      icon = "cancel",
                       text = _("No text left to add as note"),
                       timeout = 2
                   })
@@ -361,6 +365,7 @@ function ChatGPTViewer:init()
                                       { a, nb_highlights_added = -1, nb_notes_added = 1 }))
               
               UIManager:show(InfoMessage:new{
+                  icon = "info",
                   text = _("Note added successfully"),
                   timeout = 2
               })

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -293,7 +293,6 @@ function ChatGPTViewer:init()
           if self.text and self.text ~= "" then
               Device.input.setClipboardText(self.text)
               UIManager:show(InfoMessage:new{
-                  icon = "info",
                   text = _("Text copied to clipboard"),
                   timeout = 3,
               })
@@ -313,7 +312,7 @@ function ChatGPTViewer:init()
               local ui = self.ui
               if not ui or not ui.highlight then
                   UIManager:show(InfoMessage:new{
-                      icon = "cancel",
+                      icon = "notice-warning",
                       text = _("Highlight functionality not available"),
                       timeout = 2
                   })
@@ -322,7 +321,7 @@ function ChatGPTViewer:init()
               
               if not self.text or self.text == "" then
                   UIManager:show(InfoMessage:new{
-                      icon = "cancel",
+                      icon = "notice-warning",
                       text = _("No text to add as note"),
                       timeout = 2
                   })
@@ -351,7 +350,7 @@ function ChatGPTViewer:init()
                             
               if note_text == "" then
                   UIManager:show(InfoMessage:new{
-                      icon = "cancel",
+                      icon = "notice-warning",
                       text = _("No text left to add as note"),
                       timeout = 2
                   })
@@ -365,7 +364,6 @@ function ChatGPTViewer:init()
                                       { a, nb_highlights_added = -1, nb_notes_added = 1 }))
               
               UIManager:show(InfoMessage:new{
-                  icon = "info",
                   text = _("Note added successfully"),
                   timeout = 2
               })

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -20,6 +20,7 @@ end
 -- Common helper functions
 local function showLoadingDialog()
   local loading = InfoMessage:new{
+    icon = "info",
     text = _("Loading..."),
     timeout = 0.1
   }

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -21,7 +21,6 @@ end
 -- Common helper functions
 local function showLoadingDialog()
   local loading = InfoMessage:new{
-    icon = "info",
     text = _("Loading..."),
     timeout = 0.1
   }
@@ -119,7 +118,7 @@ local function handleFollowUpQuestion(message_history, new_question, ui, highlig
   -- Check if we got a valid response
   if not answer or answer == "" then
     UIManager:show(InfoMessage:new{
-      icon = "cancel",
+      icon = "notice-warning",
       text = "No response received from AI service. Please check your configuration and network connection.",
       timeout = 3
     })
@@ -280,13 +279,13 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
 
       message_history, err = handlePredefinedPrompt(direct_prompt, highlightedText, ui)
       if err then
-        UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "cancel"})
+        UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "notice-warning"})
         return
       end
       title = CONFIGURATION.features.prompts[direct_prompt].text
 
       if not message_history or #message_history < 1 then
-        UIManager:show(InfoMessage:new{text = _("Error: No response received"), icon = "cancel"})
+        UIManager:show(InfoMessage:new{text = _("Error: No response received"), icon = "notice-warning"})
         return
       end
 
@@ -335,7 +334,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
           -- Check if we got a valid response
           if not answer or answer == "" then
             UIManager:show(InfoMessage:new{
-              icon = "cancel",
+              icon = "notice-warning",
               text = "No response received from AI service. Please check your configuration and network connection.",
               timeout = 3
             })
@@ -412,7 +411,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
             UIManager:scheduleIn(0.1, function()
               local message_history, err = handlePredefinedPrompt(prompt_type, highlightedText, ui)
               if err then
-                UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "cancel"})
+                UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "notice-warning"})
                 return
               end
               createAndShowViewer(ui, highlightedText, message_history, prompt.text)

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -1,3 +1,4 @@
+local logger = require("logger")
 local InputDialog = require("ui/widget/inputdialog")
 local ChatGPTViewer = require("chatgptviewer")
 local UIManager = require("ui/uimanager")
@@ -14,7 +15,7 @@ local success, result = pcall(function() return require("configuration") end)
 if success then
   CONFIGURATION = result
 else
-  print("configuration.lua not found, skipping...")
+  logger.warn("configuration.lua not found, skipping...")
 end
 
 -- Common helper functions
@@ -118,6 +119,7 @@ local function handleFollowUpQuestion(message_history, new_question, ui, highlig
   -- Check if we got a valid response
   if not answer or answer == "" then
     UIManager:show(InfoMessage:new{
+      icon = "cancel",
       text = "No response received from AI service. Please check your configuration and network connection.",
       timeout = 3
     })
@@ -278,13 +280,13 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
 
       message_history, err = handlePredefinedPrompt(direct_prompt, highlightedText, ui)
       if err then
-        UIManager:show(InfoMessage:new{text = _("Error: " .. err)})
+        UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "cancel"})
         return
       end
       title = CONFIGURATION.features.prompts[direct_prompt].text
 
       if not message_history or #message_history < 1 then
-        UIManager:show(InfoMessage:new{text = _("Error: No response received")})
+        UIManager:show(InfoMessage:new{text = _("Error: No response received"), icon = "cancel"})
         return
       end
 
@@ -333,6 +335,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
           -- Check if we got a valid response
           if not answer or answer == "" then
             UIManager:show(InfoMessage:new{
+              icon = "cancel",
               text = "No response received from AI service. Please check your configuration and network connection.",
               timeout = 3
             })
@@ -409,7 +412,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
             UIManager:scheduleIn(0.1, function()
               local message_history, err = handlePredefinedPrompt(prompt_type, highlightedText, ui)
               if err then
-                UIManager:show(InfoMessage:new{text = _("Error: " .. err)})
+                UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "cancel"})
                 return
               end
               createAndShowViewer(ui, highlightedText, message_history, prompt.text)

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -78,7 +78,7 @@ local function showDictionaryDialog(ui, highlightedText, message_history)
 
     UIManager:show(InfoMessage:new{
       icon = "book.opened",
-      text = _("Generating Dictionary (AI) response ..."),
+      text = _("Loading..."),
       timeout = 0.1
     })
     UIManager:scheduleIn(0.1, function()

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -1,3 +1,4 @@
+local logger = require("logger")
 local api_key = nil
 local CONFIGURATION = nil
 
@@ -6,7 +7,7 @@ local success, result = pcall(function() return require("configuration") end)
 if success then
     CONFIGURATION = result
 else
-    print("No configuration found. Please set up configuration.lua")
+    logger.warn("No configuration found. Please set up configuration.lua")
 end
 
 -- Define handlers table with proper error handling
@@ -18,7 +19,7 @@ local function loadHandler(name)
     if success then
         handlers[name] = handler
     else
-        print("Failed to load " .. name .. " handler: " .. tostring(handler))
+        logger.warn("Failed to load " .. name .. " handler: " .. tostring(handler))
     end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -1,7 +1,10 @@
 local Device = require("device")
+local logger = require("logger")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local NetworkMgr = require("ui/network/manager")
 local Dispatcher = require("dispatcher")
+local UIManager = require("ui/uimanager")
+local InfoMessage = require("ui/widget/infomessage")
 local _ = require("gettext")
 
 local showChatGPTDialog = require("dialogs")
@@ -18,7 +21,7 @@ local success, result = pcall(function() return require("configuration") end)
 if success then
   CONFIGURATION = result
 else
-  print("configuration.lua not found, skipping...")
+  logger.warn("configuration.lua not found, skipping...")
 end
 
 -- Flag to ensure the update message is shown only once per session
@@ -59,9 +62,8 @@ function Assistant:init()
       enabled = Device:hasClipboard(),
       callback = function()
         if not CONFIGURATION then
-          local UIManager = require("ui/uimanager")
-          local InfoMessage = require("ui/widget/infomessage")
           UIManager:show(InfoMessage:new{
+            icon = "cancel",
             text = _("Configuration not found. Please set up configuration.lua first.")
           })
           return
@@ -96,7 +98,6 @@ function Assistant:init()
   if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.enable_AI_recap then
     local ReaderUI    = require("apps/reader/readerui")
     local ConfirmBox  = require("ui/widget/confirmbox")
-    local UIManager   = require("ui/uimanager")
     local T 		      = require("ffi/util").template
     local lfs         = require("libs/libkoreader-lfs")   -- for file attributes
     local DocSettings = require("docsettings")			      -- for document progress
@@ -142,7 +143,6 @@ function Assistant:init()
 
   -- Add Custom buttons (ones with show_on_main_popup = true)
   if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.prompts then
-    local _ = require("gettext")  -- Ensure gettext is available in this scope
     -- Create a sorted list of prompts
     local sorted_prompts = {}
     for prompt_type, prompt in pairs(CONFIGURATION.features.prompts) do
@@ -199,9 +199,8 @@ end
 -- Event handlers for gesture-triggered actions
 function Assistant:onAskAIQuestion()
   if not CONFIGURATION then
-    local UIManager = require("ui/uimanager")
-    local InfoMessage = require("ui/widget/infomessage")
     UIManager:show(InfoMessage:new{
+      icon = "cancel",
       text = _("Configuration not found. Please set up configuration.lua first.")
     })
     return true
@@ -220,18 +219,16 @@ end
 
 function Assistant:onAskAIRecap()
   if not CONFIGURATION then
-    local UIManager = require("ui/uimanager")
-    local InfoMessage = require("ui/widget/infomessage")
     UIManager:show(InfoMessage:new{
+      icon = "cancel",
       text = _("Configuration not found. Please set up configuration.lua first.")
     })
     return true
   end
   
   if not CONFIGURATION.features or not CONFIGURATION.features.enable_AI_recap then
-    local UIManager = require("ui/uimanager")
-    local InfoMessage = require("ui/widget/infomessage")
     UIManager:show(InfoMessage:new{
+      icon = "cancel",
       text = _("AI Recap feature is not enabled in configuration.")
     })
     return true

--- a/main.lua
+++ b/main.lua
@@ -63,7 +63,7 @@ function Assistant:init()
       callback = function()
         if not CONFIGURATION then
           UIManager:show(InfoMessage:new{
-            icon = "cancel",
+            icon = "notice-warning",
             text = _("Configuration not found. Please set up configuration.lua first.")
           })
           return
@@ -200,7 +200,7 @@ end
 function Assistant:onAskAIQuestion()
   if not CONFIGURATION then
     UIManager:show(InfoMessage:new{
-      icon = "cancel",
+      icon = "notice-warning",
       text = _("Configuration not found. Please set up configuration.lua first.")
     })
     return true
@@ -220,7 +220,7 @@ end
 function Assistant:onAskAIRecap()
   if not CONFIGURATION then
     UIManager:show(InfoMessage:new{
-      icon = "cancel",
+      icon = "notice-warning",
       text = _("Configuration not found. Please set up configuration.lua first.")
     })
     return true
@@ -228,7 +228,7 @@ function Assistant:onAskAIRecap()
   
   if not CONFIGURATION.features or not CONFIGURATION.features.enable_AI_recap then
     UIManager:show(InfoMessage:new{
-      icon = "cancel",
+      icon = "notice-warning",
       text = _("AI Recap feature is not enabled in configuration.")
     })
     return true

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -39,7 +39,7 @@ local function showRecapDialog(ui, title, author, progress_percent, message_hist
 
     UIManager:show(InfoMessage:new{
       icon = "book.opened",
-      text = _("Generating recap for ") .. title,
+      text = _("Loading..."),
       timeout = 0.1
     })
     UIManager:scheduleIn(0.1, function()

--- a/update_checker.lua
+++ b/update_checker.lua
@@ -15,7 +15,6 @@ local function checkForUpdates()
   end
 
   UIManager:show(InfoMessage:new{
-    icon = "info",
     text = _("Checking update for assistant.koplugin"),
     timeout = 0.1
   })
@@ -43,7 +42,6 @@ local function checkForUpdates()
             -- Show notification to the user if a new version is available
             local message = "A new version of the " .. meta.fullname .. " plugin (" .. latest_version .. ") is available. Please update!"
             local info_message = InfoMessage:new{
-                icon = "info",
                 text = message,
                 timeout = 5 -- Display message for 5 seconds
             }

--- a/update_checker.lua
+++ b/update_checker.lua
@@ -6,6 +6,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
+local Screen = require("device").screen
 
 local function checkForUpdates()
 
@@ -16,9 +17,9 @@ local function checkForUpdates()
 
   UIManager:show(InfoMessage:new{
     text = _("Checking update for assistant.koplugin"),
-    timeout = 0.1
-  })
-  UIManager:scheduleIn(0.1, function()
+    timeout = 1
+  },nil,nil,0,Screen:scaleBySize(-80))
+  UIManager:tickAfterNext(function()
     local response_body = {}
     local _, code = http.request {
       url = "https://api.github.com/repos/omer-faruq/assistant.koplugin/releases/latest",
@@ -43,9 +44,10 @@ local function checkForUpdates()
             local message = "A new version of the " .. meta.fullname .. " plugin (" .. latest_version .. ") is available. Please update!"
             local info_message = InfoMessage:new{
                 text = message,
+		show_delay = 0.1, -- Ensure the message shown is scheduled
                 timeout = 5 -- Display message for 5 seconds
             }
-            UIManager:show(info_message)
+            UIManager:show(info_message,nil,nil,0,Screen:scaleBySize(-80))
           end
         end
       end

--- a/update_checker.lua
+++ b/update_checker.lua
@@ -4,6 +4,8 @@ local json = require("json")
 local meta = require("_meta")
 local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
+local logger = require("logger")
+local _ = require("gettext")
 
 local function checkForUpdates()
 
@@ -12,39 +14,47 @@ local function checkForUpdates()
     return
   end
 
-  local response_body = {}
-  local _, code = http.request {
-    url = "https://api.github.com/repos/omer-faruq/assistant.koplugin/releases/latest",
-    headers = {
-        ["Accept"] = "application/vnd.github.v3+json"
-    },
-    sink = ltn12.sink.table(response_body)
-  }
+  UIManager:show(InfoMessage:new{
+    icon = "info",
+    text = _("Checking update for assistant.koplugin"),
+    timeout = 0.1
+  })
+  UIManager:scheduleIn(0.1, function()
+    local response_body = {}
+    local _, code = http.request {
+      url = "https://api.github.com/repos/omer-faruq/assistant.koplugin/releases/latest",
+      headers = {
+          ["Accept"] = "application/vnd.github.v3+json"
+      },
+      sink = ltn12.sink.table(response_body)
+    }
 
-  if code == 200 then
-    local data = table.concat(response_body)
-    local parsed_data = json.decode(data)
-    local latest_version = parsed_data.tag_name -- e.g., "v0.9"
-    
-    -- Safe version comparison
-    if latest_version then
-      local stripped_latest_version = latest_version:match("^v(.+)$")
-      if stripped_latest_version then
-        local latest_number = tonumber(stripped_latest_version)
-        if latest_number and meta.version and latest_number > meta.version then
-          -- Show notification to the user if a new version is available
-          local message = "A new version of the " .. meta.fullname .. " plugin (" .. latest_version .. ") is available. Please update!"
-          local info_message = InfoMessage:new{
-              text = message,
-              timeout = 5 -- Display message for 5 seconds
-          }
-          UIManager:show(info_message)
+    if code == 200 then
+      local data = table.concat(response_body)
+      local parsed_data = json.decode(data)
+      local latest_version = parsed_data.tag_name -- e.g., "v0.9"
+      
+      -- Safe version comparison
+      if latest_version then
+        local stripped_latest_version = latest_version:match("^v(.+)$")
+        if stripped_latest_version then
+          local latest_number = tonumber(stripped_latest_version)
+          if latest_number and meta.version and latest_number > meta.version then
+            -- Show notification to the user if a new version is available
+            local message = "A new version of the " .. meta.fullname .. " plugin (" .. latest_version .. ") is available. Please update!"
+            local info_message = InfoMessage:new{
+                icon = "info",
+                text = message,
+                timeout = 5 -- Display message for 5 seconds
+            }
+            UIManager:show(info_message)
+          end
         end
       end
+    else
+      logger.warn("Failed to check for updates. HTTP code:", code)
     end
-  else
-    print("Failed to check for updates. HTTP code:", code)
-  end
+  end)
 end
 
 return {


### PR DESCRIPTION
The `Recap` / `Dictionary` and `Updater` modules didn't show any message while doing networking, the screen freezes for quite a while if network/model is slow.

This PR adds a loading dialog (just like other functions) while query model. Networking actions put in async procs (`UIManager:show(...)` and then `UIManager:scheduleIn(...)` )

also, adds an icon to all info message dialogs.

and some code clean up in `main.lua`, move common widget to the top line. use `logger.warn` instead of `print()` on errors.