### PR TITLE
add ai wikipedia pre-made prompt.

### DIFF
--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -189,6 +189,13 @@ local CONFIGURATION = {
 
                                 **Input Text:** {highlight} ]], 
                 show_on_main_popup = false -- Show the button in main popup
+            },
+            wikipedia = {
+                text = "Wikipedia",
+                order = 10,
+                system_prompt = "You are an informative assistant that provides wikipedia articles.",
+                user_prompt = "I want you to act as a Wikipedia page. I will give you the name of a topic, and you will provide a summary of that topic in the format of a Wikipedia page. Your summary should be informative and factual, covering the most important aspects of the topic. Start your summary with an introductory paragraph that gives an overview of the topic. I prefer the answer in Turkish. My first topic is {highlight}",
+                show_on_main_popup = false -- Show the button in main popup
             }
         }
     }


### PR DESCRIPTION
Adds a pre-made prompt that ask the model to generate a wikipedia like article independently, without the book context.

example:

![image](https://github.com/user-attachments/assets/e7e853db-18e5-4269-93d7-08bf1d96a473)
