### PR TITLE
Fix dictionary looked up word feed to AI model

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -188,8 +188,11 @@ function Assistant:onDictButtonsReady(dict_popup, buttons)
         callback = function()
             NetworkMgr:runWhenOnline(function()
                 local showDictionaryDialog = require("dictdialog")
-                -- Pass the word from the dict_popup instead of the highlight instance:
-                showDictionaryDialog(self.ui, dict_popup.lookupword)
+		-- NOTE: `dict_popup.lookupword` is a dictionary word
+		-- in the case of complex words, eg: multicolored, only "multi-" prefix is 
+		-- looked up in dictionary (in SOEDrich). Thus the AI model doesn't know the 
+		-- original word "multicolored".  Feed the module with original text here.
+                showDictionaryDialog(self.ui, dict_popup.word)
             end)
         end,
     }})


### PR DESCRIPTION
Fix a bug that, the `Dictionary (AI)`  uses `dict_popup.lookupword` as a result to query the model, in some cases if the word is not contained in the local dictionary, the AI doesn't get the original text either.

Here's screen shoot of a complex word `multicolored`. The right bottom screenshot (green underline) is the fix.

![image](https://github.com/user-attachments/assets/6ae2e166-c8dc-426b-8e75-a162af80c374)
