### PR TITLE
fix AI service error handling

### DIFF
--- a/dialogs.lua
+++ b/dialogs.lua
@@ -113,13 +113,13 @@ local function handleFollowUpQuestion(message_history, new_question, ui, highlig
   }
   table.insert(message_history, question_message)
 
-  local answer = queryChatGPT(message_history)
+  local answer, err = queryChatGPT(message_history)
   
   -- Check if we got a valid response
-  if not answer or answer == "" then
+  if not answer or answer == "" or err ~= nil then
     UIManager:show(InfoMessage:new{
       icon = "notice-warning",
-      text = "No response received from AI service. Please check your configuration and network connection.",
+      text = "Error received from AI service." .. err or "",
       timeout = 3
     })
     return
@@ -252,7 +252,7 @@ local function handlePredefinedPrompt(prompt_type, highlightedText, ui)
     }
   }
   
-  local answer = queryChatGPT(message_history)
+  local answer, err = queryChatGPT(message_history)
   if answer then
     table.insert(message_history, {
       role = "assistant",
@@ -260,7 +260,7 @@ local function handlePredefinedPrompt(prompt_type, highlightedText, ui)
     })
   end
   
-  return message_history, nil
+  return message_history, err
 end
 
 -- Main dialog function
@@ -279,7 +279,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
 
       message_history, err = handlePredefinedPrompt(direct_prompt, highlightedText, ui)
       if err then
-        UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "notice-warning"})
+        UIManager:show(InfoMessage:new{text = err, icon = "notice-warning"})
         return
       end
       title = CONFIGURATION.features.prompts[direct_prompt].text
@@ -329,13 +329,13 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
           }
           table.insert(message_history, question_message)
 
-          local answer = queryChatGPT(message_history)
+          local answer, err = queryChatGPT(message_history)
           
           -- Check if we got a valid response
-          if not answer or answer == "" then
+          if not answer or answer == "" or err ~= nil then
             UIManager:show(InfoMessage:new{
               icon = "notice-warning",
-              text = "No response received from AI service. Please check your configuration and network connection.",
+              text = "Error received from AI service." .. err or "",
               timeout = 3
             })
             return
@@ -411,7 +411,7 @@ local function showChatGPTDialog(ui, highlightedText, direct_prompt)
             UIManager:scheduleIn(0.1, function()
               local message_history, err = handlePredefinedPrompt(prompt_type, highlightedText, ui)
               if err then
-                UIManager:show(InfoMessage:new{text = _("Error: " .. err), icon = "notice-warning"})
+                UIManager:show(InfoMessage:new{text = err, icon = "notice-warning"})
                 return
               end
               createAndShowViewer(ui, highlightedText, message_history, prompt.text)

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -83,7 +83,13 @@ local function showDictionaryDialog(ui, highlightedText, message_history)
       timeout = 0.1
     })
     UIManager:scheduleIn(0.1, function()
-      local answer = queryChatGPT(message_history)
+      local answer, err = queryChatGPT(message_history)
+
+      if err ~= nil then
+        UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err, timeout = 3 })
+	return
+      end
+
       local function createResultText(highlightedText, answer)
           local result_text
           if configuration and configuration.features and (configuration.features.render_markdown or configuration.features.render_markdown == nil) then

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -51,7 +51,12 @@ local function showRecapDialog(ui, title, author, progress_percent, message_hist
         return result_text
       end
 
-      local answer = queryChatGPT(message_history)
+      local answer, err = queryChatGPT(message_history)
+      if err ~= nil then
+        UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err, timeout = 3 })
+        return
+      end
+
       local chatgpt_viewer = ChatGPTViewer:new {
         ui = ui,
         title = _("Recap"),


### PR DESCRIPTION
Fix error handling during the calling of AI services.

the return value of `queryChatGPT()` havn't properly processed, if error occured, user only face an empty result, or a crash :(

Now the error is detected and shown in a `InfoMessage`. also logged into `crash.log`.