### PR TITLE
Show model name during waiting for response

### DIFF
--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -184,7 +184,7 @@ local CONFIGURATION = {
                                     *   List up to 3 simple synonyms (suitable for B1+ learners). Do not reuse the original word.
                                     *   Explain its meaning simply **in Turkish**, considering its context in the text. Do not reuse the original word in the explanation.
                                 2.  **Format:** Create a numbered list using this exact structure for each item:
-                                    `index: base_form : synonym1, synonym2, synonym3 : turkish_explanation`
+                                    `index. base_form : synonym1, synonym2, synonym3 : turkish_explanation`
                                 3.  **Output Content:** **ONLY** provide the numbered list. Do not include the original text, titles, or any extra sentences.
 
                                 **Input Text:** {highlight} ]], 

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -20,8 +20,11 @@ end
 
 -- Common helper functions
 local function showLoadingDialog()
+  local current_model = CONFIGURATION.provider_settings[CONFIGURATION.provider].model
   local loading = InfoMessage:new{
-    text = _("Loading..."),
+    text = _("Querying AI ...") .. "\n" .. CONFIGURATION.provider .. "/" .. current_model,
+    icon = "book.opened",
+    force_one_line = true,
     timeout = 0.1
   }
   UIManager:show(loading)

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -77,9 +77,11 @@ local function showDictionaryDialog(ui, highlightedText, message_history)
     }
     table.insert(message_history, context_message)
 
+    local current_model = configuration.provider_settings[configuration.provider].model
     UIManager:show(InfoMessage:new{
       icon = "book.opened",
-      text = _("Loading..."),
+      text = _("Querying AI ...") .. "\n" .. configuration.provider .. "/" .. current_model,
+      force_one_line = true,
       timeout = 0.1
     })
     UIManager:scheduleIn(0.1, function()
@@ -87,7 +89,7 @@ local function showDictionaryDialog(ui, highlightedText, message_history)
 
       if err ~= nil then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err, timeout = 3 })
-	return
+        return
       end
 
       local function createResultText(highlightedText, answer)

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -37,9 +37,11 @@ local function showRecapDialog(ui, title, author, progress_percent, message_hist
     }
     table.insert(message_history, context_message)
 
+    local current_model = configuration.provider_settings[configuration.provider].model
     UIManager:show(InfoMessage:new{
       icon = "book.opened",
-      text = _("Loading..."),
+      text = _("Querying AI ...") .. "\n" .. configuration.provider .. "/" .. current_model,
+      force_one_line = true,
       timeout = 0.1
     })
     UIManager:scheduleIn(0.1, function()


### PR DESCRIPTION
- shows the current model name (`platform/model`) instead of simple "Loading" during the query.
- a small adjust to the prompt, set markdown example for the model.

![image](https://github.com/user-attachments/assets/e2ff36c1-af2c-4d66-a6a6-ff5d7329d885)
