### PR TITLE
fix: update html view css to match text view better

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -43,10 +43,13 @@ local MD = require("apps/filemanager/lib/md")
 local VIEWER_CSS = [[
 @page {
     margin: 0;
+    font-family: 'Noto Sans';
 }
 
 body {
     margin: 0;
+    line-height: 1.3;
+    text-align: justify;
     padding: 0;
 }
 


### PR DESCRIPTION
- use Noto Sans font as default, it looks considerably better on e-ink
- use line-height 1.3 which makes it more similar to textbox, and looks good with noto sans
- set text-alight justify to match text box

mostly based on dictquicklookup defaults