### PR TITLE
Fixuserhili

### DIFF
--- a/dialogs.lua
+++ b/dialogs.lua
@@ -84,7 +84,7 @@ local function createContextMessage(ui, highlightedText)
       role = "user",
       content = "I'm reading something titled '" .. book.title .. "' by " .. book.author ..
         ". I have a question about the following highlighted text: " .. highlightedText .. 
-        ". If the question isn't clean enough, analyze the highlighted text.",
+        ". If the question is not clear enough, analyze the highlighted text.",
       is_context = true
     }
   else

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -65,24 +65,13 @@ local function formatUserPrompt(user_prompt, highlightedText, ui)
     :gsub("{author}", book.author)
     :gsub("{highlight}", text_to_use)
   
-  local formatted_user_content = ""
-  if string.find(user_prompt or "Please analyze: ", "{highlight}") then
-    -- If the prompt contains {highlight} placeholder, use the formatted prompt
-    if text_to_use == "" then
-      -- If no text highlighted, modify the prompt to be more general
+  local formatted_user_content = formatted_user_prompt
+
+  if string.find(user_prompt or "Please analyze: ", "{highlight}") and text_to_use == "" then
+      -- If the prompt contains {highlight} placeholder, and no text highlighted, modify the prompt to be more general
       formatted_user_content = formatted_user_prompt:gsub("the following text: ", "this book: ")
                                                    :gsub("following text", "this book")
                                                    :gsub("this text", "this book")
-    else
-      formatted_user_content = formatted_user_prompt
-    end
-  else
-    -- If no {highlight} placeholder, append the text (if any)
-    if text_to_use ~= "" then
-      formatted_user_content = formatted_user_prompt .. text_to_use
-    else
-      formatted_user_content = formatted_user_prompt .. "this book"
-    end
   end
 
   return formatted_user_content
@@ -94,7 +83,8 @@ local function createContextMessage(ui, highlightedText)
     return {
       role = "user",
       content = "I'm reading something titled '" .. book.title .. "' by " .. book.author ..
-        ". I have a question about the following highlighted text: " .. highlightedText,
+        ". I have a question about the following highlighted text: " .. highlightedText .. 
+        ". If the question isn't clean enough, analyze the highlighted text.",
       is_context = true
     }
   else

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -113,7 +113,6 @@ local function handleFollowUpQuestion(message_history, new_question, ui, highlig
     UIManager:show(InfoMessage:new{
       icon = "notice-warning",
       text = "Error received from AI service." .. err or "",
-      timeout = 3
     })
     return
   end
@@ -195,15 +194,21 @@ local function createAndShowViewer(ui, highlightedText, message_history, title, 
     ui = ui,
     onAskQuestion = function(viewer, new_question)
       NetworkMgr:runWhenOnline(function()
-        -- Use viewer's own highlighted_text value
-        local current_highlight = viewer.highlighted_text or highlightedText
-        message_history = handleFollowUpQuestion(message_history, new_question, ui, current_highlight)
-        local new_result_text = createResultText(current_highlight, message_history, viewer.text, false)
-        viewer:update(new_result_text)
-        
-        if viewer.scroll_text_w then
-          viewer.scroll_text_w:resetScroll()
-        end
+        showLoadingDialog()
+        UIManager:scheduleIn(0.1, function()
+          -- Use viewer's own highlighted_text value
+          local current_highlight = viewer.highlighted_text or highlightedText
+          local msg = handleFollowUpQuestion(message_history, new_question, ui, current_highlight)
+          if msg ~= nil then
+            message_history = msg
+            local new_result_text = createResultText(current_highlight, message_history, viewer.text, false)
+            viewer:update(new_result_text)
+            
+            if viewer.scroll_text_w then
+              viewer.scroll_text_w:resetScroll()
+            end
+          end
+        end)
       end)
     end,
     highlighted_text = highlightedText,


### PR DESCRIPTION
Fix a prompt prcess problem.

There was code to append the highlighted text before introduced the `{highlight}` keyword to all pre-made prompts. 
Now it's unnecessary and makes user's direct input prompt confusing.
 
The highlighted text is already inserted as prompt context before user's input, so it'd be better asking the model to process it insted. Simplify the prompt process logic.

Also, adding a loading msg on asking followup questions, handles API error if happened.