### PR TITLE
Adds prompt title before a follow up question

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -535,7 +535,7 @@ function ChatGPTViewer:askAnotherQuestion()
         text = prompt_config.text,
         callback = function(self, question)
           if self.onAskQuestion then
-            self.onAskQuestion(self, prompt_config.user_prompt .. "\n" .. (question or ""))
+            self.onAskQuestion(self, prompt_config.user_prompt .. "\n" .. (question or ""), prompt_config.text)
           end
         end
       })

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -183,7 +183,6 @@ local function createAndShowViewer(ui, highlightedText, message_history, title, 
     text = result_text,
     ui = ui,
     onAskQuestion = function(viewer, new_question, _title)
-        logger.info("onAskQuestion", _title)
         Trapper:wrap(function()
           -- Use viewer's own highlighted_text value
           local current_highlight = viewer.highlighted_text or highlightedText


### PR DESCRIPTION
Adds a title before a follow up action.

The text become very long when using "Ask Another Question", the action title text is added after `⮞ Assistant:`, so that it's clear that the following text belong to which question.