### PR TITLE
adds AI Provider switch dialog

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -64,6 +64,7 @@ ol, ul, menu {
 ]]
 
 local ChatGPTViewer = InputContainer:extend {
+  assitant = nil, -- The assistant object that created this viewer
   title = nil,
   text = nil,
   width = nil,
@@ -104,7 +105,6 @@ local ChatGPTViewer = InputContainer:extend {
 
 -- Global variables
 local active_chatgpt_viewer = nil
-local is_input_dialog_open = false
 
 function ChatGPTViewer:init()
   -- calculate window dimension
@@ -243,6 +243,17 @@ function ChatGPTViewer:init()
       end,
     })
   end
+
+  -- Add switch model button
+  table.insert(default_buttons, {
+    text = _("Switch Model"),
+    id = "switch_model",
+    callback = function()
+      if self.assitant then
+        self.assitant:showProviderSwitch()
+      end
+    end,
+  })
   
   -- Add the rest of the default buttons
   table.insert(default_buttons, {

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -257,7 +257,7 @@ local function showProcCustomPrompt(assitant, highlightedText, prompt_index)
 
   -- Check if Querier is initialized
   if not Querier:is_inited() then
-    local ok, err = Querier:load_model(assitant.settings:readSetting("provider") or CONFIGURATION.provider)
+    local ok, err = Querier:load_model(assitant:getModelProvider())
     if not ok then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
         return
@@ -293,7 +293,7 @@ local function showChatGPTDialog(assitant, highlightedText)
 
   -- Check if Querier is initialized
   if not Querier:is_inited() then
-    local ok, err = Querier:load_model(assitant.settings:readSetting("provider") or CONFIGURATION.provider)
+    local ok, err = Querier:load_model(assitant:getModelProvider())
     if not ok then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err})
         return

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -170,14 +170,15 @@ local function createResultText(highlightedText, message_history, previous_text,
 end
 
 -- Helper function to create and show ChatGPT viewer
-local function createAndShowViewer(ui, highlightedText, message_history, title, show_highlighted_text)
-  -- logger.info("title", title)
+local function createAndShowViewer(assitant, highlightedText, message_history, title, show_highlighted_text)
+  local ui = assitant.ui
   show_highlighted_text = show_highlighted_text == nil and true or show_highlighted_text
   local result_text = createResultText(highlightedText, message_history, nil, show_highlighted_text, title)
   local render_markdown = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.render_markdown) or true
   local markdown_font_size = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.markdown_font_size) or 20
   
   local chatgpt_viewer = ChatGPTViewer:new {
+    assitant = assitant,
     title = title,
     text = result_text,
     ui = ui,
@@ -276,7 +277,7 @@ local function showProcCustomPrompt(assitant, highlightedText, prompt_index)
     return
   end
 
-  createAndShowViewer(ui, highlightedText, message_history, title)
+  createAndShowViewer(assitant, highlightedText, message_history, title)
 end
 
 -- Main dialog function
@@ -366,7 +367,7 @@ local function showChatGPTDialog(assitant, highlightedText)
             _("Text Analysis") or 
             book.title
         
-          createAndShowViewer(ui, highlightedText, message_history, viewer_title)
+          createAndShowViewer(assitant, highlightedText, message_history, viewer_title)
         end)
       end
     }

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -7,21 +7,23 @@ local TextBoxWidget = require("ui/widget/textboxwidget")
 local _ = require("gettext")
 local Event = require("ui/event")
 local configuration = require("configuration")
-local Querier = require("gpt_query"):new()
 
-local function showDictionaryDialog(ui, highlightedText, message_history)
+local function showDictionaryDialog(assitant, highlightedText, message_history)
+    local Querier = assitant.querier
+    local ui = assitant.ui
 
     -- Check if Querier is initialized
-    local ok, err = Querier:load_model(configuration.provider)
+    local ok, err = Querier:load_model(assitant.settings:readSetting("provider") or configuration.provider)
     if not ok then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
         return
     end
 
     -- Handle case where no text is highlighted (gesture-triggered)
+    local input_dialog
     if not highlightedText or highlightedText == "" then
         -- Show a simple input dialog to ask for a word to look up
-        local input_dialog = InputDialog:new{
+        input_dialog = InputDialog:new{
             title = _("AI Dictionary"),
             input_hint = _("Enter a word to look up..."),
             input_type = "text",
@@ -41,7 +43,7 @@ local function showDictionaryDialog(ui, highlightedText, message_history)
                             UIManager:close(input_dialog)
                             if word and word ~= "" then
                                 -- Recursively call with the entered word
-                                showDictionaryDialog(ui, word, message_history)
+                                showDictionaryDialog(assitant, word, message_history)
                             end
                         end,
                     },

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -133,6 +133,7 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
     end
 
     chatgpt_viewer = ChatGPTViewer:new {
+        assitant = assitant,
         ui = ui,
         title = _("Dictionary"),
         text = result_text,

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -13,7 +13,7 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
     local ui = assitant.ui
 
     -- Check if Querier is initialized
-    local ok, err = Querier:load_model(assitant.settings:readSetting("provider") or configuration.provider)
+    local ok, err = Querier:load_model(assitant:getModelProvider())
     if not ok then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
         return

--- a/main.lua
+++ b/main.lua
@@ -114,6 +114,11 @@ function Assistant:showProviderSwitch()
 end
 
 function Assistant:getModelProvider()
+
+  if not CONFIGURATION then
+    error("Configuration not found. Please set up configuration.lua first.")
+  end
+
   local provider = self.settings:readSetting("provider", CONFIGURATION.provider)
   if CONFIGURATION and CONFIGURATION.provider_settings then
     if not CONFIGURATION.provider_settings[provider] then
@@ -144,6 +149,13 @@ function Assistant:onFlushSettings()
 end
 
 function Assistant:init()
+
+  -- skip initialization if configuration.lua is not found
+  if not CONFIGURATION then
+    logger.error("Configuration not found. Please set up configuration.lua first.")
+    return
+  end
+
   -- Register actions with dispatcher for gesture assignment
   self:onDispatcherRegisterActions()
 

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -61,6 +61,7 @@ local function showRecapDialog(assitant, title, author, progress_percent, messag
     end
 
     local chatgpt_viewer = ChatGPTViewer:new {
+      assitant = assitant,
       ui = ui,
       title = _("Recap"),
       text = createResultText(answer),

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -13,7 +13,7 @@ local function showRecapDialog(assitant, title, author, progress_percent, messag
     local ui = assitant.ui
 
     -- Check if Querier is initialized
-    local ok, err = Querier:load_model(assitant.settings:readSetting("provider") or configuration.provider)
+    local ok, err = Querier:load_model(assitant:getModelProvider())
     if not ok then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
         return

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -7,11 +7,13 @@ local Event = require("ui/event")
 local _ = require("gettext")
 local ChatGPTViewer = require("chatgptviewer")
 local configuration = require("configuration")
-local Querier = require("gpt_query"):new()
 
-local function showRecapDialog(ui, title, author, progress_percent, message_history)
+local function showRecapDialog(assitant, title, author, progress_percent, message_history)
+    local Querier = assitant.querier
+    local ui = assitant.ui
+
     -- Check if Querier is initialized
-    local ok, err = Querier:load_model(configuration.provider)
+    local ok, err = Querier:load_model(assitant.settings:readSetting("provider") or configuration.provider)
     if not ok then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
         return


### PR DESCRIPTION
Now user can switch to different model without editing the configuration.lua file.

the dialog can be accessed in 2 methods:

- Top Menu(book opened) -> TOOLS -> Page 2 `More tools` -> `Assitant Provider Switch`
- A second botton next to "Ask another question" on a response view.

**screenshot**

![image](https://github.com/user-attachments/assets/fcd06660-2d45-44a1-9212-0ca5449bffb9)
