### PR TITLE
Recap: restore to origin hook `ReaderUI.doShowReader`

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -242,16 +242,16 @@ function Assistant:init()
     local ReaderUI    = require("apps/reader/readerui")
     -- avoid recurive overrides here
     -- pulgin is loaded on every time file opened
-    if not ReaderUI._original_showReaderCoroutine then 
+    if not ReaderUI._original_doShowReader then 
       -- Save a reference to the original doShowReader method.
-      ReaderUI._original_showReaderCoroutine = ReaderUI.showReaderCoroutine
+      ReaderUI._original_doShowReader = ReaderUI.doShowReader
 
       local assitant = self -- reference to the Assistant instance
       local lfs         = require("libs/libkoreader-lfs")   -- for file attributes
       local DocSettings = require("docsettings")			      -- for document progress
     
-      -- Override to hook into the reader's showReaderCoroutine method.
-      function ReaderUI:showReaderCoroutine(file, provider, seamless)
+      -- Override to hook into the reader's doShowReader method.
+      function ReaderUI:doShowReader(file, provider, seamless)
 
         -- Get file metadata; here we use the file's "access" attribute.
         local attr = lfs.attributes(file)
@@ -287,7 +287,7 @@ function Assistant:init()
             })
           end
         end
-        return ReaderUI._original_showReaderCoroutine(self, file, provider, seamless)
+        return ReaderUI._original_doShowReader(self, file, provider, seamless)
       end
     end
   end

--- a/main.lua
+++ b/main.lua
@@ -262,7 +262,9 @@ function Assistant:init()
           local percent_finished = doc_settings:readSetting("percent_finished") or 0
           local timeDiffHours = (os.time() - lastAccess) / 3600.0
     
-          if timeDiffHours >= 28 and percent_finished <= 0.95 then -- More than 28hrs since last open and less than 95% complete
+          -- More than 28hrs since last open and less than 95% complete
+          -- percent = 0 may means the book is not started yet, the docsettings maybe empty
+          if timeDiffHours >= 28 and percent_finished > 0 and percent_finished <= 0.95 then 
             -- Construct the message to display.
             local doc_props = doc_settings:child("doc_props")
             local title = doc_props:readSetting("title", "Unknown Title")


### PR DESCRIPTION
the last PR  #53 introduced another bug during digging with different approch, the recap dialog shows before the book opened.
