### PR TITLE
Profile visible settings discussed in #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,13 @@ local CONFIGURATION = {
     provider = "openai",
     -- or 
     provider = "openai_grok", -- latter one is in effective
+    -- or you can choose one in the Model Provider Switch
     
     -- Provider-specific settings (override defaults in api_handlers/defaults.lua)
     provider_settings = {
         openai = {
+            defalut = true, -- optional, if provider is not set, will try to find the one with `defalut =  true`
+            visible = true, -- optional, if set to false, will not shown in the profile switch
             model = "api-model",
             base_url = "URL_to_API",
             api_key = "your-api-key", -- set your api key here

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -6,16 +6,9 @@ local CONFIGURATION = {
 
     -- Provider-specific settings
     provider_settings = {
-        anthropic = {
-            model = "claude-3-5-haiku-latest", -- model list: https://docs.anthropic.com/en/docs/about-claude/models
-            base_url = "https://api.anthropic.com/v1/messages",
-            api_key = "your-anthropic-api-key",
-            additional_parameters = {
-                anthropic_version = "2023-06-01", -- api version list: https://docs.anthropic.com/en/api/versioning
-                max_tokens = 4096
-            }
-        },
         openai = {
+            defalut = true, -- optional, if provider above is not set, will try to find one with `defalut =  true`
+            visible = true, -- optional, if set to false, will not shown in the provider switch
             model = "gpt-4o-mini", -- model list: https://platform.openai.com/docs/models
             base_url = "https://api.openai.com/v1/chat/completions",
             api_key = "your-openai-api-key",
@@ -31,6 +24,16 @@ local CONFIGURATION = {
             api_key = "your-grok-api-key",
             additional_parameters = {
                 temperature = 0.7,
+                max_tokens = 4096
+            }
+        },
+        anthropic = {
+            visible = true, -- optional, if set to false, will not shown in the profile switch
+            model = "claude-3-5-haiku-latest", -- model list: https://docs.anthropic.com/en/docs/about-claude/models
+            base_url = "https://api.anthropic.com/v1/messages",
+            api_key = "your-anthropic-api-key",
+            additional_parameters = {
+                anthropic_version = "2023-06-01", -- api version list: https://docs.anthropic.com/en/api/versioning
                 max_tokens = 4096
             }
         },

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -34,7 +34,7 @@ function Querier:init(provider_name)
         return _("No configuration found. Please set up configuration.lua")
     end
 
-    if CONFIGURATION and CONFIGURATION.provider then
+    if CONFIGURATION and CONFIGURATION.provider_settings then
 
         --- Check if the provider is set in the configuration
         if CONFIGURATION.provider_settings and CONFIGURATION.provider_settings[provider_name] then

--- a/main.lua
+++ b/main.lua
@@ -129,13 +129,14 @@ end
 
 function Assistant:getModelProvider()
 
-  if not CONFIGURATION then
+  if not (CONFIGURATION and CONFIGURATION.provider_settings) then
     error("Configuration not found. Please set up configuration.lua first.")
   end
 
-  local setting_provider = nil
-  local provider_settings = CONFIGURATION.provider_settings
-
+  local provider_settings = CONFIGURATION.provider_settings -- provider settings table from configuration.lua
+  local setting_provider = nil -- provider name from LuaSettings
+  
+  -- settings may not be initialized, so check if self.settings exists
   if self.settings and next(self.settings.data) ~= nil then
     setting_provider = self.settings:readSetting("provider")
   end
@@ -144,12 +145,15 @@ function Assistant:getModelProvider()
     -- If the setting provider is valid, use it
     return setting_provider
   else
-    local conf_provider = CONFIGURATION.provider
-    -- If the setting provider is invalid, check the configuration provider
+    -- If the setting provider is invalid, try to find one from configuration
+
+    local conf_provider = CONFIGURATION.provider -- provider name from configuration.lua
+
     if provider_settings[conf_provider] then
+      -- if the configuration provider is valid, use it
       setting_provider = conf_provider
     else
-      -- If both are invalid, try to find the one defined with `default = true`
+      -- still invalid, try to find the one defined with `default = true`
       for key, tab in pairs(CONFIGURATION.provider_settings) do
         if tab.default then
           setting_provider = key

--- a/main.lua
+++ b/main.lua
@@ -87,8 +87,10 @@ function Assistant:showProviderSwitch()
 
     -- sort keys of provider_settings
     local provider_keys = {}
-    for key, _ in pairs(provider_settings) do
-      table.insert(provider_keys, key)
+    for key, tab in pairs(provider_settings) do
+      if tab.visible ~= false then
+        table.insert(provider_keys, key)
+      end
     end
     table.sort(provider_keys)
 
@@ -143,14 +145,21 @@ function Assistant:getModelProvider()
     if provider_settings[conf_provider] then
       setting_provider = conf_provider
     else
-      -- If both are invalid, log a warning and use a random one available provider
-      local function first_key(t)
-        for k, _ in pairs(t) do
-          return k
+      -- If both are invalid, try to find the one defined with `default = true`
+      for key, tab in pars(CONFIGURATION.provider_settings) do
+        if tab.default then
+          setting_provider = key
+          break
         end
       end
-      setting_provider = first_key(CONFIGURATION.provider_settings)
-      logger.warn("Invalid provider setting found, using random one: ", setting_provider)
+      
+      -- still invalid (none of them defined `default`)
+      if not provider_settings[conf_provider] then
+        -- log a warning and use a random one available provider
+        local function first_key(t) for k, _ in pairs(t) do return k end end
+        setting_provider = first_key(CONFIGURATION.provider_settings)
+        logger.warn("Invalid provider setting found, using random one: ", setting_provider)
+      end
     end
     self.settings:saveSetting("provider", setting_provider)
     self.updated = true -- mark settings as updated

--- a/main.lua
+++ b/main.lua
@@ -222,17 +222,9 @@ function Assistant:init()
     return
   end
 
-  local provider = self:getModelProvider()
-  -- Initialize settings file
-  if next(self.settings.data) == nil then -- first run with no settings
-    self.settings:saveSetting("provider", provider)
-    logger.info("Assistant settings initialized with provider: ", provider)
-    self.updated = true
-  end
-
   -- Load the model provider from settings or default configuration
   self.querier = require("gpt_query"):new()
-  self.querier:load_model(provider)
+  self.querier:load_model(self:getModelProvider())
 
   -- Dictionary button
   if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.dictionary_translate_to and CONFIGURATION.features.show_dictionary_button_in_main_popup then


### PR DESCRIPTION
- use `visible = false` to hide a provider profile, (following the same logic with `show_on_main_popup = false` in prompt config)
- adds `default = true` to help selecting a provider if the `provider =` is not defined (if multiple default is defined, the result will be  a random one)