### PR TITLE
fix configuration sample; rename to configuration.sample.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You'll need API keys for the AI service you want to use:
 
 ### 3. Configure the Plugin
 
-1. Copy `configuration.lua.sample` to `configuration.lua` ( do not modify the sample file)
+1. Copy `configuration.sample.lua` to `configuration.lua` ( do not modify the sample file)
 2. Edit the `configuration.lua` file as needed.
     - Set the chosen AI provider in `provider`
     - Set your API keys in `provider_settings` 
@@ -86,7 +86,7 @@ You'll need API keys for the AI service you want to use:
 
 #### Advanced Configuration:
 
-The plugin supports extensive customization through `configuration.lua`. See the [sample file](https://raw.githubusercontent.com/omer-faruq/assistant.koplugin/refs/heads/main/configuration.lua.sample) for all options:
+The plugin supports extensive customization through `configuration.lua`. See the [sample file](https://raw.githubusercontent.com/omer-faruq/assistant.koplugin/refs/heads/main/configuration.sample.lua) for all options:
 
 - Multiple AI providers with different settings
     - An underscore in `provider` means to use the first part as the handler, various profiles for each API.

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -159,7 +159,7 @@ Above all else do not give any spoilers to the book, only consider prior content
 Focus on the more recent content rather than a general summary to help the user pick up where they left off.
 Match the tone and energy of the book, for example if the book is funny match that style of humor and tone, if it's an exciting fantasy novel show it, if it's a historical or sad book reflect that.
 Use text bolding to emphasize names and locations. Use italics to emphasize major plot points. No emojis or symbols.
-Answer this whole response in {language} language. Only show the replies, do not give a description.]]
+Answer this whole response in {language} language. Only show the replies, do not give a description.]],
             language = "Turkish" -- Language for recap responses, uses dictionary_translate_to as fallback
         },
 


### PR DESCRIPTION
- fix a syntax error in the example configuration
- renname example file to `configuration.sample.lua` to allow regular syntax check
- updated doc