### PR TITLE
Support Responses endpoint over Chat Completions endpoint for OpenAI, default config implicitly to English

### DIFF
--- a/api_handlers/openai.lua
+++ b/api_handlers/openai.lua
@@ -4,13 +4,108 @@ local logger = require("logger")
 
 local OpenAIHandler = BaseHandler:new()
 
+local function extract_output_text(responseData)
+    -- 1. Direct field on the response (most common)
+    if responseData.output_text and responseData.output_text ~= "" then
+        return responseData.output_text
+    end
+
+    -- 2. Iterate through the output array for the first chunk that contains text
+    if responseData.output and type(responseData.output) == "table" then
+        for _, item in ipairs(responseData.output) do
+            -- Items with a direct text field
+            if item.text and item.text ~= "" then
+                return item.text
+            end
+            -- Items with nested content list (e.g., messages)
+            if item.content and type(item.content) == "table" then
+                for _, sub in ipairs(item.content) do
+                    if sub.text and sub.text ~= "" then
+                        return sub.text
+                    end
+                end
+            end
+        end
+    end
+    return nil
+end
+
 function OpenAIHandler:query(message_history, openai_settings)
-    
-    local requestBodyTable = {
-        model = openai_settings.model,
-        messages = message_history,
-        max_tokens = openai_settings.max_tokens
-    }
+    -- Extract the most recent user message as single-turn input, as multi-turn is not required.
+    local user_message = ""
+    if message_history and #message_history > 0 then
+        -- find the last message with role "user"; fallback to the last message
+        for i = #message_history, 1, -1 do
+            local m = message_history[i]
+            if m.role == "user" or i == #message_history then
+                user_message = m.content or ""
+                break
+            end
+        end
+    end
+
+    -- Determine whether to use the new Responses API or legacy Chat Completions based on the URL
+    local using_responses_api = openai_settings.base_url and string.find(openai_settings.base_url, "/responses") ~= nil
+
+    local requestBodyTable
+
+    if using_responses_api then
+        -- Build body for Responses API
+        requestBodyTable = {
+            model = openai_settings.model,
+            input = user_message,
+        }
+
+        -- Merge any additional parameters directly into the request body
+        if openai_settings.additional_parameters then
+            for k, v in pairs(openai_settings.additional_parameters) do
+                if k == "max_tokens" then
+                    -- map to the new parameter name
+                    requestBodyTable.max_output_tokens = v
+                elseif k ~= "messages" and k ~= "n" and k ~= "logprobs" and k ~= "logit_bias" and k ~= "presence_penalty" and k ~= "frequency_penalty" then
+                    -- Pass through other parameters that are still valid in the Responses API
+                    requestBodyTable[k] = v
+                end
+            end
+        end
+
+        -- Handle legacy max_tokens field mapping specified at the top level
+        if openai_settings.max_tokens and not requestBodyTable.max_output_tokens then
+            requestBodyTable.max_output_tokens = openai_settings.max_tokens
+        end
+
+        -- Optionally enable the built-in web search tool
+        if openai_settings.enable_web_search then
+            -- Ensure a tools array exists
+            requestBodyTable.tools = requestBodyTable.tools or {}
+
+            -- Check if web_search tool already present
+            local has_web_search = false
+            for _, t in ipairs(requestBodyTable.tools) do
+                if t.type == "web_search" then
+                    has_web_search = true
+                    break
+                end
+            end
+
+            if not has_web_search then
+                table.insert(requestBodyTable.tools, { type = "web_search" })
+            end
+        end
+    else
+        -- Fallback to legacy Chat Completions format for backwards compatibility
+        requestBodyTable = {
+            model = openai_settings.model,
+            messages = message_history,
+            max_tokens = openai_settings.max_tokens
+        }
+
+        if openai_settings.additional_parameters then
+            for k, v in pairs(openai_settings.additional_parameters) do
+                requestBodyTable[k] = v
+            end
+        end
+    end
 
     local requestBody = json.encode(requestBodyTable)
     local headers = {
@@ -18,21 +113,43 @@ function OpenAIHandler:query(message_history, openai_settings)
         ["Authorization"] = "Bearer " .. (openai_settings.api_key)
     }
 
-    local status, code, response = self:makeRequest(openai_settings.base_url, headers, requestBody)
+    -- Web-search augmented responses can take longer; bump max timeouts when we know a tool is in play.
+    local timeout, maxtime
+    if using_responses_api and openai_settings.enable_web_search then
+        timeout, maxtime = 60, 180 -- seconds: wait longer than defaults
+    end
+
+    local status, code, response = self:makeRequest(openai_settings.base_url, headers, requestBody, timeout, maxtime)
 
     if status then
         local success, responseData = pcall(json.decode, response)
-        if success and responseData and responseData.choices and responseData.choices[1] then
-            return responseData.choices[1].message.content
+        if success and responseData then
+            if using_responses_api then
+                local content_text = extract_output_text(responseData)
+                if content_text then
+                    return content_text
+                end
+            else
+                if responseData.choices and responseData.choices[1] then
+                    -- chat completion or completion style
+                    if responseData.choices[1].message and responseData.choices[1].message.content then
+                        return responseData.choices[1].message.content
+                    elseif responseData.choices[1].text then
+                        return responseData.choices[1].text
+                    end
+                end
+            end
+
+            -- server response error message inside JSON
+            if responseData.error and responseData.error.message then
+                return nil, responseData.error.message
+            end
         end
-        
-        -- server response error message
+
+        -- Couldn't parse or unexpected structure
         logger.warn("API Error", code, response)
-        if success and responseData and responseData.error and responseData.error.message then
-            return nil, responseData.error.message 
-        end
     end
-    
+
     if code == BaseHandler.CODE_CANCELLED then
         return nil, response
     end

--- a/api_handlers/openai.lua
+++ b/api_handlers/openai.lua
@@ -50,10 +50,27 @@ function OpenAIHandler:query(message_history, openai_settings)
     local requestBodyTable
 
     if using_responses_api then
-        -- Build body for Responses API
+        -- Convert the conversation history (excluding the system prompt) to Responses API input items
+        local input_items = {}
+        if message_history and #message_history > 0 then
+            for _, msg in ipairs(message_history) do
+                if msg.role ~= "system" then
+                    table.insert(input_items, {
+                        role = msg.role,
+                        content = msg.content,
+                    })
+                end
+            end
+        end
+
+        -- Fallback to single user message if somehow empty
+        if #input_items == 0 then
+            input_items = user_message
+        end
+
         requestBodyTable = {
             model = openai_settings.model,
-            input = user_message,
+            input = input_items,
         }
 
         -- If the first message is a system prompt, map it to `instructions`

--- a/api_handlers/openai.lua
+++ b/api_handlers/openai.lua
@@ -56,6 +56,11 @@ function OpenAIHandler:query(message_history, openai_settings)
             input = user_message,
         }
 
+        -- If the first message is a system prompt, map it to `instructions`
+        if message_history and #message_history > 0 and message_history[1].role == "system" then
+            requestBodyTable.instructions = message_history[1].content
+        end
+
         -- Merge any additional parameters directly into the request body
         if openai_settings.additional_parameters then
             for k, v in pairs(openai_settings.additional_parameters) do

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -134,8 +134,8 @@ local CONFIGURATION = {
 
     -- Optional features 
     features = {
-        dictionary_translate_to = "Turkish", -- Set language for the dictionary response, nil to disable dictionary.
-        response_language = "Turkish", --  Set language for the other responses, nil to English response. 
+        dictionary_translate_to = "English", -- Default translation target; change if desired.
+        response_language = nil, --  Nil means default to English; change to another language to localize all answers.
         hide_highlighted_text = false,  -- Set to true to hide the highlighted text at the top
         hide_long_highlights = true,    -- Hide highlighted text if longer than threshold
         long_highlight_threshold = 500,  -- Number of characters considered "long"
@@ -188,7 +188,7 @@ Answer this whole response in {language} language. Only show the replies, do not
                 text = "Explain",
                 order = 3,
                 system_prompt = "You are a helpful assistant that explains complex topics clearly and concisely. Break down concepts into simple terms.",
-                user_prompt = "Please explain the following text. Answer in {language}: {highlight}",
+                user_prompt = "Please explain the following text: {highlight}",
                 show_on_main_popup = false -- Show the button in main popup
             },
             summarize = {
@@ -202,28 +202,28 @@ Answer this whole response in {language} language. Only show the replies, do not
                 text = "Historical Context",
                 order = 5,
                 system_prompt = "You are a historical context expert. Provide relevant historical background and connections.",
-                user_prompt = "Explain the historical context of this text. Answer in {language}: {highlight}",
+                user_prompt = "Explain the historical context of this text: {highlight}",
                 show_on_main_popup = false -- Show the button in main popup
             },
             key_points = {
                 text = "Key Points",
                 order = 6,
                 system_prompt = "You are a key points expert. Provide a concise list of key points from the text.",
-                user_prompt = "Please provide a concise list in markdown format of key points from the following text. Answer in {language}: {highlight}",
+                user_prompt = "Please provide a concise list in markdown format of key points from the following text: {highlight}",
                 show_on_main_popup = false -- Show the button in main popup
             },
             ELI5 = {
                 text = "ELI5",
                 order = 7,
                 system_prompt = "You are an ELI5 expert. Provide simple, concise explanations for complex terms.",
-                user_prompt = "Please provide an ELI5 explanation. Answer in {language}: {highlight}",
+                user_prompt = "Please provide an ELI5 explanation: {highlight}",
                 show_on_main_popup = false -- Show the button in main popup
             },
             grammar = {
                 text = "Grammar",
                 order = 8,
                 system_prompt = "You are a grammar expert.",
-                user_prompt = "Explain the grammar of the following text. Answer in {language}: {highlight}",
+                user_prompt = "Explain the grammar of the following text: {highlight}",
                 show_on_main_popup = true -- Show the button in main popup
             },
             vocabulary = {
@@ -237,9 +237,9 @@ Answer this whole response in {language} language. Only show the replies, do not
                                     *   Correct any typos.
                                     *   Convert it to its base form (e.g., "go", "dog", "good", "kick the bucket").
                                     *   List up to 3 simple synonyms (suitable for B1+ learners). Do not reuse the original word.
-                                    *   Explain its meaning simply **in {language}**, considering its context in the text. Do not reuse the original word in the explanation.
+                                    *   Explain its meaning simply **in English**, considering its context in the text. Do not reuse the original word in the explanation.
                                 2.  **Format:** Create a numbered list using this exact structure for each item:
-                                    `index. base_form : synonym1, synonym2, synonym3 : {language}_explanation`
+                                    `index. base_form : synonym1, synonym2, synonym3 : English_explanation`
                                 3.  **Output Content:** **ONLY** provide the numbered list. Do not include the original text, titles, or any extra sentences.
 
                                 **Input Text:** {highlight} ]], 

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -409,7 +409,8 @@ local function showChatGPTDialog(assitant, highlightedText)
               input_dialog = nil
             end
             Trapper:wrap(function()
-              showProcCustomPrompt(ui, highlightedText, tab.idx)
+              -- Pass the assistant instance so showProcCustomPrompt can access querier and ui
+              showProcCustomPrompt(assitant, highlightedText, tab.idx)
             end)
           end
         })


### PR DESCRIPTION
I installed this plugin to try to get AI assistance with questions about AI Engineering textbooks... and used AI to help make some changes I needed. 😅

# Purpose

1. The[ Responses endpoint](https://platform.openai.com/docs/api-reference/responses) supports more features, including larger context windows and improved web search _(via tool use, supporting `gpt-4.1` and currently planned to support `o3` soon)_. For all intents and purposes, this is the "superior" OpenAI API endpoint moving forward. As far as I'm aware, it was built to combine the use-cases for the Chat Completions and Assistant APIs, and is likely to serve as their eventual replacement.
2. "Answer in _________" prompts add noise to the LLM. The default language of these prompts is implicitly English, as the prompts themselves are written in English _(if other languages are meant to be supported, true support would mean that the prompts themselves should be written in those languages, carrying forward the cultural context of those languages as per [Linguistic Relativity](https://en.wikipedia.org/wiki/Linguistic_relativity))_.

# Note

Changes are smoke-tested and seem to be working, but are AI-written. Any disfluences or weird bugs can be chalked up to that _(I don't write Lua daily, made these changes for my own use in my fork, and am offering them as an improvement to merge)_. If the format of the changes seems odd, feel free to tweak.

Changes should also be backwards-compatible; The Chat Completions endpoint is expected to remain working fully. I smoke-tested this a couple of times throughout my changes, but haven't tested it thoroughly or considered it deeply, since my own personal use-case was to switch to the Responses API entirely _(all of the time)_.