### PR TITLE
refactor ChatGPTDialog to AssistantDialog as OOP 

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -545,7 +545,7 @@ function ChatGPTViewer:askAnotherQuestion()
         text = prompt_config.text,
         callback = function(self, question)
           if self.onAskQuestion then
-            self.onAskQuestion(self, prompt_config.user_prompt .. "\n" .. (question or ""), prompt_config.text)
+            self.onAskQuestion(self, prompt_config.user_prompt, false) -- false indicates button pressed (custom prompt)
           end
         end
       })
@@ -580,7 +580,7 @@ function ChatGPTViewer:askAnotherQuestion()
         self.input_dialog = nil
         
         if self.onAskQuestion then
-          self.onAskQuestion(self, question)
+          self.onAskQuestion(self, question, true) -- true indicates user entered question
         end
       end
     }

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -63,7 +63,6 @@ ol, ul, menu {
 ]]
 
 local ChatGPTViewer = InputContainer:extend {
-  assitant = nil, -- The assistant object that created this viewer
   title = nil,
   text = nil,
   width = nil,
@@ -97,7 +96,8 @@ local ChatGPTViewer = InputContainer:extend {
   default_hold_callback = nil,   -- on each default button
   find_centered_lines_count = 5, -- line with find results to be not far from the center
 
-  onAskQuestion = nil,
+  onShowSwitchModel = nil, -- callback when the Switch Model button is pressed
+  onAskQuestion = nil, -- callback when the Ask Another Question button is pressed
   input_dialog = nil,
   showAskQuestion = true,
 }
@@ -248,8 +248,8 @@ function ChatGPTViewer:init()
     text = _("Switch Model"),
     id = "switch_model",
     callback = function()
-      if self.assitant then
-        self.assitant:showProviderSwitch()
+      if self.onShowSwitchModel then
+        self.onShowSwitchModel()
       end
     end,
   })

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -775,8 +775,6 @@ function ChatGPTViewer:handleTextSelection(text, hold_duration, start_idx, end_i
 end
 
 function ChatGPTViewer:update(new_text)
-  -- Attempt to load configuration
-  local success, CONFIGURATION = pcall(function() return require("configuration") end)
   local first_time = not self.text
 
   -- Check if the new text is substantially different from the current text
@@ -825,8 +823,9 @@ function ChatGPTViewer:update(new_text)
     -- Always scroll to the new text except first time
     if not first_time then
       if self.render_markdown then
-        -- If rendering in a ScrollHtmlWidget, use scrollToRatio
-        --self.scroll_text_w:scrollToRatio(1)
+        -- HTMLWidget only supports scroll by page
+        -- scroll to bottom would be weired mostly. keep it to top here
+        self.scroll_text_w:resetScroll()
       else
         self.scroll_text_w:scrollToBottom()
       end

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -12,7 +12,6 @@ local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
-local CheckButton = require("ui/widget/checkbutton")
 local Device = require("device")
 local logger = require("logger")
 local Event = require("ui/event")
@@ -570,7 +569,13 @@ function ChatGPTViewer:askAnotherQuestion()
       is_enter_default = true,
       callback = function()
         local question = self.input_dialog:getInputText()
-        
+        if not question or question == "" then
+          UIManager:show(InfoMessage:new{
+            text = _("Enter a question before proceeding."),
+            timeout = 3
+          })
+          return
+        end
         UIManager:close(self.input_dialog)
         self.input_dialog = nil
         

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -545,7 +545,7 @@ function ChatGPTViewer:askAnotherQuestion()
         text = prompt_config.text,
         callback = function(self, question)
           if self.onAskQuestion then
-            self.onAskQuestion(self, prompt_config.user_prompt, false) -- false indicates button pressed (custom prompt)
+            self.onAskQuestion(self, prompt_config) -- question is table (configed prompt)
           end
         end
       })
@@ -580,7 +580,7 @@ function ChatGPTViewer:askAnotherQuestion()
         self.input_dialog = nil
         
         if self.onAskQuestion then
-          self.onAskQuestion(self, question, true) -- true indicates user entered question
+          self.onAskQuestion(self, question) -- question is string (user input)
         end
       end
     }
@@ -831,11 +831,7 @@ function ChatGPTViewer:update(new_text)
         self.scroll_text_w:scrollToBottom()
       end
     end
-
-    -- Refresh the screen after displaying the results
-    if success and CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.refresh_screen_after_displaying_results then
-      UIManager:setDirty(nil, "full")
-    end
+    UIManager:setDirty(self.scroll_text_w, "partial")
   end
 end
 

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -239,7 +239,7 @@ Answer this whole response in {language} language. Only show the replies, do not
                                     *   List up to 3 simple synonyms (suitable for B1+ learners). Do not reuse the original word.
                                     *   Explain its meaning simply **in {language}**, considering its context in the text. Do not reuse the original word in the explanation.
                                 2.  **Format:** Create a numbered list using this exact structure for each item:
-                                    `index. base_form : synonym1, synonym2, synonym3 : {language}_explanation`
+                                    `index. base form : synonym1, synonym2, synonym3 : {language} explanation`
                                 3.  **Output Content:** **ONLY** provide the numbered list. Do not include the original text, titles, or any extra sentences.
 
                                 **Input Text:** {highlight} ]], 

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -119,8 +119,16 @@ function AssitantDialog:_createResultText(highlightedText, message_history, prev
   local last_assistant_message = message_history[#message_history]
 
   -- Concatenate previous_text with the newly formatted messages
-  return previous_text .. "------------\n\n" .. 
+  local formatted_text = previous_text .. "------------\n\n"
+  
+  -- custom prompt have title, no need to include it in the message
+  if title and title ~= "" then
+    formatted_text = formatted_text .. formatSingleMessage(last_assistant_message, title)
+  else
+    formatted_text = formatted_text .. 
       formatSingleMessage(last_user_message, title) .. formatSingleMessage(last_assistant_message, title)
+  end
+  return formatted_text
 end
 
 -- Helper function to create and show ChatGPT viewer

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -9,14 +9,12 @@ local Trapper = require("ui/trapper")
 -- main dialog class
 local AssitantDialog = {
   input_dialog = nil,
-  config = nil,
 }
 AssitantDialog.__index = AssitantDialog
 
 function AssitantDialog:new(assitant, config)
   local self = setmetatable({}, AssitantDialog)
   self.assitant = assitant
-  self.ui = assitant.ui
   self.querier = assitant.querier
   self.config = config
   return self
@@ -164,7 +162,7 @@ function AssitantDialog:_createAndShowViewer(highlightedText, message_history, t
     assitant = self.assitant,
     title = title,
     text = result_text,
-    ui = self.ui,
+    ui = self.assitant.ui,
     onAskQuestion = function(viewer, new_question, _title)
         Trapper:wrap(function()
           -- Use viewer's own highlighted_text value
@@ -196,7 +194,7 @@ function AssitantDialog:_createAndShowViewer(highlightedText, message_history, t
 end
 
 function AssitantDialog:_getBookContext()
-  local prop = self.ui.document:getProps()
+  local prop = self.assitant.ui.document:getProps()
   return {
     title = prop.title or _("Unknown Title"),
     author = prop.authors or _("Unknown Author")
@@ -386,7 +384,6 @@ end
 function AssitantDialog:showCustomPrompt(highlightedText, prompt_index)
 
   local CONFIGURATION = self.config
-  local title = self.config.features.prompts[prompt_index].text or prompt_index
   if not CONFIGURATION or not CONFIGURATION.features or not CONFIGURATION.features.prompts then
     return nil, "No prompts configured"
   end
@@ -396,6 +393,7 @@ function AssitantDialog:showCustomPrompt(highlightedText, prompt_index)
     return nil, string.format("Prompt %s not found", prompt_index)
   end
 
+  local title = self.config.features.prompts[prompt_index].text or prompt_index
   local user_content = self:_formatUserPrompt(prompt.user_prompt, highlightedText)
   local message_history = {
     {
@@ -409,7 +407,7 @@ function AssitantDialog:showCustomPrompt(highlightedText, prompt_index)
     }
   }
   
-  local answer, err = self.querier:query(message_history, string.format("🌐 Loading %s ...", title or prompt_idx))
+  local answer, err = self.querier:query(message_history, string.format("🌐 Loading for %s ...", title or prompt_index))
   if err then
     UIManager:show(InfoMessage:new{text = err, icon = "notice-warning"})
     return

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -69,11 +69,18 @@ function AssitantDialog:_createResultText(highlightedText, message_history, prev
   local function formatSingleMessage(message, title)
     if not message then return "" end
     if message.role == "user" then
-      local user_content = message.content or _("(Empty message)")
-      return string.format("### ⮞ User: %s\n\n%s\n\n", title or "", self:_truncateUserPrompt(user_content))
+      local user_message
+      if title and title ~= "" then
+        -- shows "User: <title>" if title is provided
+        user_message = string.format("%s\n\n", title)
+      else
+        -- shows user input prompt
+        user_message = string.format("\n\n%s\n\n", self:_truncateUserPrompt(message.content or _("(Empty message)")))
+      end
+      return "### ⮞ User: " .. user_message
     elseif message.role == "assistant" then
       local assistant_content = message.content or _("(No response)")
-      return string.format("### ⮞ Assistant: %s\n\n%s\n\n", title or "", assistant_content)
+      return string.format("### ⮞ Assistant:\n\n%s\n\n", assistant_content)
     end
     return "" -- Should not happen for valid roles
   end
@@ -118,17 +125,8 @@ function AssitantDialog:_createResultText(highlightedText, message_history, prev
   local last_user_message = message_history[#message_history - 1]
   local last_assistant_message = message_history[#message_history]
 
-  -- Concatenate previous_text with the newly formatted messages
-  local formatted_text = previous_text .. "------------\n\n"
-  
-  -- custom prompt have title, no need to include it in the message
-  if title and title ~= "" then
-    formatted_text = formatted_text .. formatSingleMessage(last_assistant_message, title)
-  else
-    formatted_text = formatted_text .. 
+  return previous_text .. "------------\n\n" ..
       formatSingleMessage(last_user_message, title) .. formatSingleMessage(last_assistant_message, title)
-  end
-  return formatted_text
 end
 
 -- Helper function to create and show ChatGPT viewer

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -139,10 +139,12 @@ function AssitantDialog:_createAndShowViewer(highlightedText, message_history, t
   local markdown_font_size = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.markdown_font_size) or 20
   
   local chatgpt_viewer = ChatGPTViewer:new {
-    assitant = self.assitant,
     title = title,
     text = result_text,
     ui = self.assitant.ui,
+    onShowSwitchModel = function() -- callback for switch model button
+      self.assitant:showProviderSwitch()
+    end,
     onAskQuestion = function(viewer, user_question) -- callback for user entered question
         -- Use viewer's own highlighted_text value
         local current_highlight = viewer.highlighted_text or highlightedText


### PR DESCRIPTION
Mostly a code refactor PR, not much feature changes.

1. rewrite `ChatGPTDialog` to `AssistantDialog` class, simplifing function calls, without passing around references.
2. clearify some function names, funcion with prefix `_` means module internal use.
3. pass a callback func `onShowSwitchModel` instead of the whole `assitant` main object to the viewer.
4. avoid user inputs an empty question.
5. when `Ask Another Question`  and clicks a button, shows `> User: Translate` as user content line instead of the very long custom defined prompt.