### PR TITLE
fix: improve scrolling behavior in ChatGPTViewer update function

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -763,6 +763,7 @@ end
 
 function ChatGPTViewer:update(new_text)
   local first_time = not self.text
+  local last_page_num = nil
 
   -- Check if the new text is substantially different from the current text
   if not self.text or #new_text > #self.text then
@@ -770,6 +771,10 @@ function ChatGPTViewer:update(new_text)
     self.text = new_text
 
     if self.render_markdown then
+
+      -- remenber the last page number
+      last_page_num = self.scroll_text_w.htmlbox_widget.page_count
+
       -- Convert Markdown to HTML and recreate the ScrollHtmlWidget with the new text
       local html_body, err = MD(self.text, {})
       if err then
@@ -810,14 +815,17 @@ function ChatGPTViewer:update(new_text)
     -- Always scroll to the new text except first time
     if not first_time then
       if self.render_markdown then
-        -- HTMLWidget only supports scroll by page
-        -- scroll to bottom would be weired mostly. keep it to top here
-        self.scroll_text_w:resetScroll()
+        -- ScrollHtmlWidget only supports scroll by ratio
+        -- Scroll to the last page if it exists
+        local current_page_num = self.scroll_text_w.htmlbox_widget.page_count
+        if last_page_num and last_page_num > 0 and current_page_num > 0 then
+          self.scroll_text_w:scrollToRatio((last_page_num - 1) / current_page_num)
+        end
       else
         self.scroll_text_w:scrollToBottom()
       end
     end
-    UIManager:setDirty(self.scroll_text_w, "partial")
+    UIManager:setDirty(self.frame, "partial")
   end
 end
 


### PR DESCRIPTION
when using "ask another question", the result are concated, but the scroll position was not right.

- use the last time total pages count to calculate the scroll position.
- the scrollbar seems buggy, but that's a koreader offcial widget, maybe try to fix it to upstream.