### PR TITLE
add mac installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ You'll need API keys for the AI service you want to use:
    - Kindle: `koreader/plugins/`
    - PocketBook: `applications/koreader/plugins/`
    - Android: `koreader/plugins/`
+   - Mac: `KOReader.app/Contents/koreader/plugins/` (Right-click on `KOReader.app` in Finder, and click **Show Package Contents** to open it as a folder.)
 3. Create/modify `configuration.lua` as needed.
 
 #### Using A Stable Release:
@@ -74,6 +75,7 @@ You'll need API keys for the AI service you want to use:
    - Kindle: `koreader/plugins/`
    - PocketBook: `applications/koreader/plugins/`
    - Android: `koreader/plugins/`
+   - Mac: `KOReader.app/Contents/koreader/plugins/` (Right-click on `KOReader.app` in Finder, and click **Show Package Contents** to open it as a folder.)
 3. Create/modify `configuration.lua` as needed.
 
 ### 3. Configure the Plugin


### PR DESCRIPTION
This screenshot can be added to the rename too if needed.

![image](https://github.com/user-attachments/assets/42e79284-6e91-4993-a7d6-c0bc3ce2f3e1)

BTW, I think we should reduce the redundancy here in maybe another pull request like this:

```
1. Download the plugin
- Stable release: download + extract
- Latest version: clone + rename
2. Move `assistant.koplugin` to platform-specific folder
3. Create/modify configuration.lua as needed
```