### PR TITLE
fix SwitchModel button in recap and dict dialog

### DIFF
--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -101,7 +101,6 @@ local ChatGPTViewer = InputContainer:extend {
   onShowSwitchModel = nil, -- callback when the Switch Model button is pressed
   onAskQuestion = nil, -- callback when the Ask Another Question button is pressed
   input_dialog = nil,
-  showAskQuestion = true,
 }
 
 -- Global variables
@@ -235,7 +234,7 @@ function ChatGPTViewer:init()
   local default_buttons = {}
   
   -- Only add Ask Another Question button if showAskQuestion is true
-  if self.showAskQuestion ~= false then
+  if self.onAskQuestion then
     table.insert(default_buttons, {
       text = _("Ask Another Question"),
       id = "ask_another_question",
@@ -246,15 +245,19 @@ function ChatGPTViewer:init()
   end
 
   -- Add switch model button
-  table.insert(default_buttons, {
-    text = _("Switch Model"),
-    id = "switch_model",
-    callback = function()
-      if self.onShowSwitchModel then
-        self.onShowSwitchModel()
-      end
-    end,
-  })
+  if self.onShowSwitchModel then
+    -- Only add if the callback is defined
+    -- This allows the button to be optional
+    table.insert(default_buttons, {
+      text = _("Switch Model"),
+      id = "switch_model",
+      callback = function()
+        if self.onShowSwitchModel then
+          self.onShowSwitchModel()
+        end
+      end,
+    })
+  end
   
   -- Add the rest of the default buttons
   table.insert(default_buttons, {

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -175,6 +175,9 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
         title = _("Dictionary"),
         text = result_text,
         onAddToNote = handleAddToNote,
+        onShowSwitchModel = function()
+            assitant:showProviderSwitch()
+        end,
     }
 
     UIManager:show(chatgpt_viewer)

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -174,7 +174,6 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
         ui = ui,
         title = _("Dictionary"),
         text = result_text,
-        showAskQuestion = false,
         onAddToNote = handleAddToNote,
     }
 

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -67,7 +67,6 @@ local function showRecapDialog(assitant, title, author, progress_percent, messag
       ui = ui,
       title = _("Recap"),
       text = createResultText(answer),
-      showAskQuestion = false
     }
 
     UIManager:show(chatgpt_viewer)

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -67,6 +67,9 @@ local function showRecapDialog(assitant, title, author, progress_percent, messag
       ui = ui,
       title = _("Recap"),
       text = createResultText(answer),
+      onShowSwitchModel = function()
+        assitant:showProviderSwitch()
+      end,
     }
 
     UIManager:show(chatgpt_viewer)


### PR DESCRIPTION
- SwitchModel button was not working in recap and dict dialog, for the callback was not defined.
- remove `ChatGPTViewer.showAskQuestion` flag variable, instead, only show the button when the callback is defined. same rule goes to `ChatGPTViewer:onShowSwitchModel`.