### PR TITLE
fix: mac plugin folder location

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Copy the `assistant.koplugin` directory (obtained from step 2.1) to your KOReade
 *   **Kindle:** `koreader/plugins/`
 *   **PocketBook:** `applications/koreader/plugins/`
 *   **Android:** `koreader/plugins/`
-*   **Mac:** `KOReader.app/Contents/koreader/plugins/` (Right-click on `KOReader.app` in Finder, and click **Show Package Contents** to open it as a folder.)
+*   **Mac:** `~/Library/Application Support/koreader/plugins/`
 
 #### 2.3. Create/modify configuration.lua as needed
 


### PR DESCRIPTION
I just realized there's another koreader folder on mac. Both install the plugin, but `~/Library/Application Support/koreader` is probably better than the one in `.app`, which is presumably for built-in functions.