### PR TITLE
enhance translate override 

### DIFF
--- a/dialogs.lua
+++ b/dialogs.lua
@@ -398,6 +398,8 @@ function AssitantDialog:showCustomPrompt(highlightedText, prompt_index)
   local prompt_config = Prompts.getMergedCustomPrompts()[prompt_index]
 
   local title = prompt_config.text or prompt_index
+
+  highlightedText = highlightedText:gsub("\n", "\n\n") -- ensure newlines are doubled (LLM presumes markdown input)
   local user_content = self:_formatUserPrompt(prompt_config.user_prompt, highlightedText)
   local message_history = {
     {

--- a/main.lua
+++ b/main.lua
@@ -76,23 +76,21 @@ function Assistant:addToMainMenu(menu_items)
         end
     }
 
-    if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.dictionary_translate_to then
-      menu_items.assitant_dictionary_override = {
+    if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language then
+      menu_items.assitant_translate_override = {
           text = _("Use AI Assistant for 'Translate'"),
           checked_func = function()
-              return self.settings:readSetting("ai_dictionary_override") or false
+              return self.settings:readSetting("ai_translate_override") or false
           end,
           callback = function()
-              local current_setting = self.settings:readSetting("ai_dictionary_override") or false
+              local current_setting = self.settings:readSetting("ai_translate_override") or false
               local new_setting = not current_setting
-              self.settings:saveSetting("ai_dictionary_override", new_setting)
+              self.settings:saveSetting("ai_translate_override", new_setting)
               self.updated = true
-
+              self:applyOrRemoveTranslateOverride()
               UIManager:show(InfoMessage:new{
                   text = new_setting and _("AI Assistant override enabled.") or _("AI Assistant override disabled.")
               })
-
-              self:applyOrRemoveTranslateOverride()
           end,
           sorting_hint = "more_tools",
       }
@@ -452,19 +450,15 @@ end
 
 -- Override the translate method in ReaderHighlight to use AI Assistant
 function Assistant:applyOrRemoveTranslateOverride()
-  if not self.ui.highlight then
-    logger.warn("ReaderHighlight not available, cannot apply or remove override")
-    return
-  end
 
   local Translator = require("ui/translator")
-
   -- Store original translate method if not already stored
   if not Translator._original_showTranslation then
     Translator._original_showTranslation = Translator.showTranslation
   end
 
-  local should_override = CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.dictionary_translate_to and self.settings:readSetting("ai_dictionary_override")
+  local should_override = CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language and
+      self.settings:readSetting("ai_translate_override")
 
   if should_override then
     -- Apply the override

--- a/main.lua
+++ b/main.lua
@@ -470,7 +470,6 @@ function Assistant:applyOrRemoveTranslateOverride()
     -- Apply the override
     if Translator.showTranslation == Translator._original_showTranslation then
       self:_overrideTranslateMethod()
-      logger.info("Assistant: translate method overridden with AI Assistant")
     end
   else
     -- Remove the override
@@ -494,10 +493,10 @@ function Assistant:_overrideTranslateMethod()
       })
       return
     end
-    
+
+    local words = FrontendUtil.splitToWords(text)
     NetworkMgr:runWhenOnline(function()
       Trapper:wrap(function()
-        local words = FrontendUtil.splitToWords(text)
         -- splitToWords result like this: { "The", " ", "good", " ", "news" }
         if #words > 5 then
             self.assitant_dialog:showCustomPrompt(text, "translate")
@@ -509,7 +508,7 @@ function Assistant:_overrideTranslateMethod()
       end)
     end)
   end
-  logger.info("Assistant: translate method overridden with AI Dictionary")
+  logger.info("Assistant: translate method overridden with AI Assistant")
 end
 
 return Assistant

--- a/prompts.lua
+++ b/prompts.lua
@@ -133,20 +133,21 @@ Answer this whole response in {language} language. Only show the replies, do not
     dict = {
         system_prompt = "You are a dictionary with high quality detail vocabulary definitions and examples. Always respond in Markdown format.",
         user_prompt = [[
-"Explain vocabulary or content with the focus word with following information:"
-"- *Conjugation*. Vocabulary in original conjugation if its different than the form in the sentence."
-"- *Synonyms*. 3 synonyms for the word if available."
-"- *Meaning*. Meaning of the expression without reference to context. Answer this part in {language} language."
-"- *Translate*. Translation of the the whole sentence with word. Highlight in bold the word that is being translated. Answer this part in {language} language."
-"- *Explanation*. Explanation of the content according to context. Answer this part in {language} language."
-"- *Example*. Another example sentence. Answer this part in the original language of the sentence."
-"- *Origin*. Origin of that word, tracing it back to its ancient roots. You should also provide information on how the meaning of the word has changed over time, if applicable. Answer this part in {language} language." ..
-"Only show the requested replies, do not give a description, answer in markdown list format."
+"Explain vocabulary or content with the focus text with following information:"
+"- *Conjugation*: Vocabulary in original conjugation if its different than the form in the sentence."
+"- *Synonyms*: 3 synonyms for the word if available."
+"- *Meaning*: Meaning of the expression without reference to context. Answer this part in {language} language."
+"- *Translation*: Translation of the the whole sentence with word. Highlight in bold the word that is being translated. Answer this part in {language} language."
+"- *Explanation*: Explanation of the content according to context. Answer this part in {language} language."
+"- *Example*: Another example sentence. Answer this part in the original language of the sentence."
+"- *Word Origin*: Origin of that word, tracing it back to its ancient roots. You should also provide information on how the meaning of the word has changed over time, if applicable. Answer this part in {language} language." ..
+
+"Only show the requested replies, do not give a description."
 
 [CONTEXT]
 {context}
 
-[FOCUS WORD]
+[FOCUS TEXT]
 {word}]]
     }
 }


### PR DESCRIPTION
- Auto detect: shows AI Dictionary when the selected text is short (3 or less words), shows Translate when text is long.
- override the koreader `Translater` (now the build in function 'Translate current page' calls our method too.)<img width="220" height="256" alt="image" src="https://github.com/user-attachments/assets/5392393d-cefb-42de-8de3-46eee7b6a195" />
- adds additional newlines before sending to LLM (markdown format)
- small adjust to Dictionary prompt.

