### PR TITLE
Full featured markdown parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /configuration.lua
 /apikeys.lua
+lib/*.so.*
 .DS_Store

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -35,7 +35,7 @@ local util = require("util")
 local _ = require("gettext")
 local InfoMessage = require("ui/widget/infomessage")
 local Screen = Device.screen
-local MD = require("apps/filemanager/lib/md")
+local MD = require("mdparser")
 
 local Prompts = require("prompts")
 
@@ -49,18 +49,42 @@ local VIEWER_CSS = [[
 
 body {
     margin: 0;
-    line-height: 1.3;
-    text-align: justify;
+    line-height: 1.25;
     padding: 0;
 }
 
-blockquote, dd {
+blockquote, dd, pre {
     margin: 0 1em;
 }
 
 ol, ul, menu {
     margin: 0;
-    padding-left: 1.7em;
+    padding-left: 1.5em;
+}
+
+ul {
+    list-style-type: square;
+}
+
+ul ul {
+    list-style-type: circle;
+}
+
+ul ul ul {
+    list-style-type: disc;
+}
+
+table {
+    margin: 0;
+    padding: 0;
+    border-collapse: collapse;
+    border-spacing: 0;
+    font-size: 0.8em;
+}
+
+table td, table th {
+    border: 1px solid black;
+    padding: 0;
 }
 ]]
 

--- a/mdparser.lua
+++ b/mdparser.lua
@@ -5,26 +5,30 @@ local Parser = nil
 
 local logger = require("logger")
 local DataStorage = require("datastorage")
-local lfs = require("libs/libkoreader-lfs")
 local plugin_lib_dir = DataStorage:getDataDir() .. "/plugins/assistant.koplugin/lib"
 local ffi = require("ffi")
 local LibHoedown = nil
 
 -- check if hoedown is natively available
+-- mostly it's unavailable on KOReader, but available on some other platforms
 local ok, _lib = pcall(ffi.loadlib, "hoedown", 3)
 if ok then Libhoedown = _lib end 
 
 -- check if hoedown is available in the plugin directory
+-- in order to use native hoedown, a "lib" directory containing "libhoedown.so.3" and resty-hoedown 
+-- should be present in the plugin directory, see documents for more details
 if not LibHoedown then
     local ok, _lib = pcall(ffi.load, plugin_lib_dir .. "/libhoedown.so.3")
     if ok then LibHoedown = _lib end
 end
 
 if LibHoedown then
+    -- hook the C binding of hoedown to the resty.hoedown library
     package.preload["resty.hoedown.library"] = function()
         return LibHoedown
     end
 
+    -- load the resty.hoedown library from the plugin's libs directory
     package.path = string.format("%s;%s/?.lua", package.path, plugin_lib_dir)
     local ok, hoedownMD = pcall(require, "resty.hoedown")
     if ok then
@@ -42,8 +46,8 @@ if LibHoedown then
     end
 end
 
+-- fallback to pure Lua implementation
 if not Parser then
-    -- fallback to pure Lua implementation
     Parser = require("apps/filemanager/lib/md")
     logger.info("Using markdown.lua (pure Lua) for markdown parsing")
 end

--- a/mdparser.lua
+++ b/mdparser.lua
@@ -1,0 +1,51 @@
+-- markdown parser wrapper module
+-- This module provides a simple interface to use hoedown (C binding of full features markdown)
+-- or the pure Lua implementation of markdown.lua (building on KOReader)
+local Parser = nil
+
+local logger = require("logger")
+local DataStorage = require("datastorage")
+local lfs = require("libs/libkoreader-lfs")
+local plugin_lib_dir = DataStorage:getDataDir() .. "/plugins/assistant.koplugin/lib"
+local ffi = require("ffi")
+local LibHoedown = nil
+
+-- check if hoedown is natively available
+local ok, _lib = pcall(ffi.loadlib, "hoedown", 3)
+if ok then Libhoedown = _lib end 
+
+-- check if hoedown is available in the plugin directory
+if not LibHoedown then
+    local ok, _lib = pcall(ffi.load, plugin_lib_dir .. "/libhoedown.so.3")
+    if ok then LibHoedown = _lib end
+end
+
+if LibHoedown then
+    package.preload["resty.hoedown.library"] = function()
+        return LibHoedown
+    end
+
+    package.path = string.format("%s;%s/?.lua", package.path, plugin_lib_dir)
+    local ok, hoedownMD = pcall(require, "resty.hoedown")
+    if ok then
+        Parser = function (text)
+            return hoedownMD(text, {
+                rendered    = "html",
+                nesting     = 1,
+                extensions  = {
+                    "space_headers", "tables", "fenced_code", "footnotes", "autolink", "strikethrough",
+                    "underline", "highlight", "quote", "superscript", "math", "math_explicit",
+                },
+            })
+        end
+        logger.info("Using hoedown (C binding) for markdown parsing")
+    end
+end
+
+if not Parser then
+    -- fallback to pure Lua implementation
+    Parser = require("apps/filemanager/lib/md")
+    logger.info("Using markdown.lua (pure Lua) for markdown parsing")
+end
+
+return Parser


### PR DESCRIPTION
Introduce a full featured markdown parser, hoedown. We can see table results from the AI response.

But hoedown is C written, and compiled to shared object, makes this feature platform dependence.
All linux-based native KOReader's (kindle, kobo, remarkable, tolino ...) should be easily enable this feature, only some [extra steps](https://github.com/boypt/hoedown4eink?tab=readme-ov-file#install) needed.  Android platform is not available now, until the KOReader includes hoedown in the App.

I believe this feature is not necessary for normal users (AI not always generate complicated results containing tables). It will use the buildin pure LUA parser as before. **This feature is like a plugin to the plugin.**

Also minor changed to the viewer CSS:
- default text no longer justify, just show the default way (helps to non-justify languages, like Arabic)
- the default `disc` is a very small dot in unorder list, use square and circles instead. 

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/b41d2f43-763b-4951-b49e-6ab0afbf8cd9" />
