### PR TITLE
Hold buttons to add/remove from main popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ local CONFIGURATION = {
     
     -- Optional features
     features = {
-        dictionary_translate_to = "Turkish", -- Set language for the dictionary response, nil to disable dictionary.
         response_language = "Turkish", --  Set language for the other responses, nil to English response. 
+        -- dictionary_translate_to = "German", -- if you want the language of the dictionary to be different from the response language, set it here.
         hide_highlighted_text = false,  -- Set to true to hide the highlighted text at the top
         hide_long_highlights = true,    -- Hide highlighted text if longer than threshold
         long_highlight_threshold = 500,  -- Number of characters considered "long"

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ local CONFIGURATION = {
         long_highlight_threshold = 500,  -- Number of characters considered "long"
         max_display_user_prompt_length = 100,  -- Maximum number of characters of user_prompt to show in result window  (0 or nil for no limit)
         system_prompt = "You are a helpful assistant that provides clear explanations.", -- Custom system prompt for the AI ("Ask" button) to override the default, to disable set to nil
-        show_dictionary_button_in_main_popup = true, -- Set to true to show the dictionary button in the main popup
         show_dictionary_button_in_dictionary_popup = true, -- Set to true to show the Dictionary (AI) button in the dictionary popup
         enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
         render_markdown = true, -- Set to true to render markdown in the AI responses

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ local CONFIGURATION = {
                 order = 1, -- give order to buttons to fix the order of them
                 system_prompt = "You are a helpful assistant that ....",
                 user_prompt = "Please ...  in {language}: ",
-                show_on_main_popup = false -- Show the button in main popup    
             },
             -- ... other prompts
         }

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -141,7 +141,6 @@ local CONFIGURATION = {
         long_highlight_threshold = 500,  -- Number of characters considered "long"
         max_display_user_prompt_length = 100,  -- Maximum number of characters of user_prompt to show in result window  (0 or nil for no limit)
         system_prompt = "You are a helpful AI assistant. Always respond in Markdown format.", -- Custom system prompt for the AI ("Ask" button) to override the default, to disable set to nil
-        show_dictionary_button_in_main_popup = true, -- Set to true to show the dictionary button in the main popup
         show_dictionary_button_in_dictionary_popup = true, -- Set to true to show the Dictionary (AI) button in the dictionary popup
         enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
         render_markdown = true, -- Set to true to render markdown in the AI responses

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -134,8 +134,8 @@ local CONFIGURATION = {
 
     -- Optional features 
     features = {
-        dictionary_translate_to = "Turkish", -- Set language for the dictionary response, nil to disable dictionary.
         response_language = "Turkish", --  Set language for the other responses, nil to English response. 
+        -- dictionary_translate_to = "Turkish", -- if you want the language of the dictionary to be different from the response language, set it here.
         hide_highlighted_text = false,  -- Set to true to hide the highlighted text at the top
         hide_long_highlights = true,    -- Hide highlighted text if longer than threshold
         long_highlight_threshold = 500,  -- Number of characters considered "long"

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -155,22 +155,9 @@ local CONFIGURATION = {
         -- Set `visible = false` to hide the prompt from all popups.
         prompts = {
 
-            -- set the most frequently used prompts useable in the highlighted popup
-            translate          = { show_on_main_popup = true, },
-            vocabulary         = { show_on_main_popup = true, },
-            wikipedia          = { show_on_main_popup = true, },
-
             -- hide some prompts to keep the UI clean
             -- simplify           = { visible = false, }, -- hide from everywhere
 
-            -- all other prompts are available by clicking the "Assitant" button without any configuration.
-            -- simplify           = { show_on_main_popup = true, },
-            -- explain            = { show_on_main_popup = true, },
-            -- summarize          = { show_on_main_popup = true, },
-            -- key_points         = { show_on_main_popup = true, },
-            -- historical_context = { show_on_main_popup = true, },
-            -- ELI5               = { show_on_main_popup = true, },
-            -- grammar            = { show_on_main_popup = true, },
             --
             -- example of adding a custom prompt:
             -- myprompt = { system_prompt = "you are a helpful assitant.", user_prompt = "...", order = 50, show_on_main_popup = true, },

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -340,7 +340,7 @@ function AssitantDialog:show(highlightedText)
           local button_text = is_shown and _("Remove") or _("Add")
           local action_desc = is_shown and _("Remove this button from the Main Highlight Menu?") or _("Add this button to the Main Highlight Menu?")  
           UIManager:show(ConfirmBox:new{
-            text = tab.desc .. "\n\n" .. action_desc,
+            text = string.format("%s: %s\n\n%s", tab.text, tab.desc, action_desc),
             ok_text = button_text,
             ok_callback = function()
               self.assitant.settings:toggle(settingkey)

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -3,6 +3,7 @@ local InputDialog = require("ui/widget/inputdialog")
 local ChatGPTViewer = require("chatgptviewer")
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
+local ConfirmBox = require("ui/widget/confirmbox")
 local _ = require("gettext")
 local Trapper = require("ui/trapper")
 local Prompts = require("prompts")
@@ -334,24 +335,36 @@ function AssitantDialog:show(highlightedText)
         hold_callback = function()
           local menukey = string.format("assistant_%02d_%s", tab.order, tab.idx)
           local settingkey = "showOnMain_" .. menukey
-          self.assitant.settings:toggle(settingkey)
-          self.assitant.updated = true
 
-          local noticetext
-          if self.assitant.settings:isTrue(settingkey) then
-            self.assitant:addMainButton(tab.idx, tab)
-            -- logger.info("Added custom prompt button: ", tab.text, " with index: ", tab.idx)
-            noticetext = string.format(_("Added [%s (AI)] to Main Highlight Menu."), tab.text)
-          else
-            self.assitant:removeMainButton(tab.idx, tab)
-            noticetext = string.format(_("Removed [%s (AI)] from Main Highlight Menu."), tab.text)
-          end
+          local is_shown = self.assitant.settings:isTrue(settingkey) 
+          local button_text = is_shown and _("Remove") or _("Add")
+          local action_desc = is_shown and _("Remove this button from the Main Highlight Menu?") or _("Add this button to the Main Highlight Menu?")  
+          UIManager:show(ConfirmBox:new{
+            text = tab.desc .. "\n\n" .. action_desc,
+            ok_text = button_text,
+            ok_callback = function()
+              self.assitant.settings:toggle(settingkey)
+              self.assitant.updated = true
 
-          UIManager:show(InfoMessage:new{
-            text = noticetext,
-            icon = "notice-info",
-            timeout = 3
+              local noticetext
+              if self.assitant.settings:isTrue(settingkey) then
+                self.assitant:addMainButton(tab.idx, tab)
+                -- logger.info("Added custom prompt button: ", tab.text, " with index: ", tab.idx)
+                noticetext = string.format(_("Added [%s (AI)] to Main Highlight Menu."), tab.text)
+              else
+                self.assitant:removeMainButton(tab.idx, tab)
+                noticetext = string.format(_("Removed [%s (AI)] from Main Highlight Menu."), tab.text)
+              end
+
+              UIManager:show(InfoMessage:new{
+                text = noticetext,
+                icon = "notice-info",
+                timeout = 3
+              })
+            end,
           })
+
+
         end
       })
     end

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -307,20 +307,6 @@ function AssitantDialog:show(highlightedText)
   
   -- Only add additional buttons if there's highlighted text
   if is_highlighted then
-    -- Add Dictionary button
-    if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.dictionary_translate_to then
-      table.insert(all_buttons, {
-        text = _("Dictionary"),
-        callback = function()
-          self:_close()
-          local showDictionaryDialog = require("dictdialog")
-          Trapper:wrap(function()
-            showDictionaryDialog(self.assitant, highlightedText)
-          end)
-        end
-      })  
-    end
-
     local sorted_prompts = Prompts.getSortedCustomPrompts(function (prompt)
       if prompt.visible == false then
         return false
@@ -336,7 +322,13 @@ function AssitantDialog:show(highlightedText)
         callback = function()
           self:_close()
           Trapper:wrap(function()
-            self:showCustomPrompt(highlightedText, tab.idx)
+            if tab.order == -10 and tab.idx == "dictionary" then
+              -- Special case for dictionary prompt
+              local showDictionaryDialog = require("dictdialog")
+              showDictionaryDialog(self.assitant, highlightedText)
+            else
+              self:showCustomPrompt(highlightedText, tab.idx)
+            end
           end)
         end,
         hold_callback = function()

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -395,7 +395,6 @@ function AssitantDialog:show(highlightedText)
   }
   
   UIManager:show(self.input_dialog)
-  self.input_dialog:onShowKeyboard() -- Show keyboard immediately
 end
 
 -- Process main select popup buttons

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -114,7 +114,7 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
         end
     end
     
-    local dict_language = configuration.features and configuration.features.dictionary_translate_to or "English"
+    local dict_language = configuration.features.dictionary_translate_to or configuration.features.response_language or "English"
     local context_message = {
         role = "user",
         content = string.gsub(dict_prompts.user_prompt, "{(%w+)}", {

--- a/main.lua
+++ b/main.lua
@@ -191,24 +191,6 @@ function Assistant:init()
   self.querier:load_model(self:getModelProvider())
 
   self.assitant_dialog = AssistantDialog:new(self, CONFIGURATION)
-
-  -- Dictionary button
-  if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.dictionary_translate_to and CONFIGURATION.features.show_dictionary_button_in_main_popup then
-    self.ui.highlight:addToHighlightDialog("dictionary", function(_reader_highlight_instance)
-      return {
-          text = _("Dictionary").." (AI)",
-          enabled = Device:hasClipboard(),
-          callback = function()
-              NetworkMgr:runWhenOnline(function()
-                local showDictionaryDialog = require("dictdialog")
-                Trapper:wrap(function()
-                  showDictionaryDialog(self, _reader_highlight_instance.selected_text.text)
-                end)
-              end)
-          end,
-      }
-    end)
-  end
   
   -- Recap Feature
   if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.enable_AI_recap then
@@ -317,7 +299,14 @@ function Assistant:addMainButton(prompt_idx, prompt)
       callback = function()
         NetworkMgr:runWhenOnline(function()
           Trapper:wrap(function()
-            self.assitant_dialog:showCustomPrompt(_reader_highlight_instance.selected_text.text, prompt_idx)
+            if prompt.order == -10 and prompt_idx == "dictionary" then
+              -- Dictionary prompt, show dictionary dialog
+              local showDictionaryDialog = require("dictdialog")
+              showDictionaryDialog(self, _reader_highlight_instance.selected_text.text)
+            else
+              -- For other prompts, show the custom prompt dialog
+              self.assitant_dialog:showCustomPrompt(_reader_highlight_instance.selected_text.text, prompt_idx)
+            end
           end)
         end)
       end,

--- a/main.lua
+++ b/main.lua
@@ -270,24 +270,7 @@ function Assistant:init()
 
   -- Add buttons in sorted order
   for _, tab in ipairs(showOnMain) do
-    -- Use order in the index for proper sorting (pad with zeros for consistent sorting)
-    self.ui.highlight:addToHighlightDialog(
-      string.format("assistant_%02d_%s", tab.order, tab.idx),
-      function(_reader_highlight_instance)
-        return {
-          text = tab.text .. " (AI)",  -- append "(AI)" to identify as our function
-          enabled = Device:hasClipboard(),
-          callback = function()
-            NetworkMgr:runWhenOnline(function()
-              Trapper:wrap(function()
-                self.assitant_dialog:showCustomPrompt(
-                  _reader_highlight_instance.selected_text.text,
-                  tab.idx)
-              end)
-            end)
-          end,
-        }
-      end)
+    self:addMainButton(tab.idx, tab)
   end
 end
 

--- a/prompts.lua
+++ b/prompts.lua
@@ -13,6 +13,11 @@
 
 -- prompts attributes can be overridden in the configuration file.
 local custom_prompts = {
+        dictionary = {
+            order = -10,
+            text = "Dictionary",
+            -- this prompt is a stub -- it will be replaced by the actual prompt in the code below
+        },
         translate = {
             order = 100,
             text = "Translate",

--- a/prompts.lua
+++ b/prompts.lua
@@ -1,3 +1,4 @@
+local _ = require("gettext")
 -- preconfigured prompts for various tasks
 
 -- Custom prompts for the AI
@@ -15,12 +16,14 @@
 local custom_prompts = {
         dictionary = {
             order = -10,
-            text = "Dictionary",
+            text = _("Dictionary"),
+            desc = _("This prompt act as a dictionary for the highlighted text, to a word or phrase."),
             -- this prompt is a stub -- it will be replaced by the actual prompt in the code below
         },
         translate = {
             order = 100,
-            text = "Translate",
+            text = _("Translate"),
+            desc = _("This prompt translates the highlighted text to another language."),
             user_prompt = [[You are a helpful translation assistant. Provide direct translations without additional commentary. 
 You are a skilled translator tasked with translating text from one language to another. Your goal is to provide an accurate and natural-sounding translation that preserves the meaning, tone, and style of the original text.
 [TEXT TO BE TRANSLATED]
@@ -42,8 +45,9 @@ Follow these steps to complete the translation:
 Output only the translated text without any further explanation.]],
         },
         simplify = {
-            text = "Simplify",
+            text = _("Simplify"),
             order = 110,
+            desc = _("This prompt simplifies the highlighted text to make it easier to understand."),
             user_prompt = [[You are an experienced linguistic expert and an effective communicator, skilled at transforming complex content into clear, easily understandable expressions.
 I have a piece of text that I need you to simplify using its original language. 
 Please ensure that during the simplification process, you do not alter the text's original meaning or omit any critical information. 
@@ -53,8 +57,9 @@ Your goal is to enhance the text's readability and clarity, making it accessible
 {highlight}]],
         },
         explain = {
-            text = "Explain",
+            text = _("Explain"),
             order = 120,
+            desc = _("This prompt explains the highlighted text in detail, ensuring clarity and understanding."),
             user_prompt = [[You are an expert Explainer and a highly skilled Cross-Cultural Communicator.
 Your task is to accurately and comprehensively explain any given text. 
 When I provide you with text, regardless of its original language, your primary goal is to fully grasp its meaning, including all complex terms, underlying concepts, and implicit details. 
@@ -65,8 +70,9 @@ Ensure your {language} explanation is precise, captures all nuances of the origi
 {highlight}]],
         },
         summarize = {
-            text = "Summarize",
+            text = _("Summarize"),
             order = 130,
+            desc = _("This prompt summarizes the highlighted text, capturing its main points and essential details."),
             user_prompt = [[
 You are an exceptionally skilled summarization expert and a master of linguistic precision. 
 Your core competency is to distill extensive information into its most essential form while rigorously adhering to the original language of the input text. 
@@ -75,29 +81,34 @@ This summary must accurately capture every main point and crucial detail, elimin
 Please provide a concise and clear summary of the following text in its own language: {highlight}]],
         },
         historical_context = {
-            text = "Historical Context",
+            text = _("Historical Context"),
             order = 140,
+            desc = _("This prompt provides a detailed historical context for the highlighted text, explaining its significance and background."),
             user_prompt = "You are a distinguished Historical Context Expert with profound knowledge of global history, socio-political movements, and cultural evolution. You possess an exceptional ability to place any given text within its precise historical framework. When I provide you with a text, your primary task is to meticulously uncover and articulate its relevant historical background, including the significant events, prevailing ideologies, societal structures, scientific advancements, and cultural environment that shaped its creation and meaning. Beyond merely listing facts, you must forge clear, insightful connections between these historical elements and the text's content, themes, and underlying messages. Furthermore, your comprehensive explanation must be delivered entirely in the language specified by me. Please provide a detailed and insightful explanation of the historical context of the following text, rendered completely in {language}: {highlight}",
         },
         key_points = {
-            text = "Key Points",
+            text = _("Key Points"),
             order = 150,
+            desc = _("This prompt extracts and lists the key points from the highlighted text, ensuring clarity and organization."),
             user_prompt = "You are a highly analytical and extremely efficient Key Points Expert, adept at distilling any given text into its fundamental essence. Your primary function is to meticulously identify and extract all the critical insights, core arguments, essential facts, and conclusive statements from the provided content. Your goal is to produce a summary that is not just concise but also remarkably comprehensive in its coverage of the main points, leaving out all superfluous information. You must then present these key points in a meticulously organized and easy-to-read list, ensuring each point is clear, independent, and directly addresses a central idea of the original text. All output must be exclusively in the language I specify. Please provide a concise and clear list of key points from the following text, and rendered entirely in {language}: {highlight}",
         },
         ELI5 = {
-            text = "ELI5",
+            text = _("ELI5"),
             order = 160,
+            desc = _("This prompt explains the highlighted text as if to a five-year-old, simplifying complex concepts into easily understandable terms."),
             user_prompt = "You are an exceptional ELI5 (Explain Like I'm 5) Expert, mastering the art of simplifying the most intricate concepts. Your unique talent lies in transforming complex terms or ideas into effortlessly understandable explanations, as if speaking to a curious five-year-old. When I provide you with a concept, your task is to strip away all jargon, technicalities, and unnecessary complexities, focusing solely on the fundamental essence. You must use only plain, everyday language, simple analogies, and concise sentences to ensure immediate comprehension for anyone, regardless of their background knowledge. Your explanation should be direct, clear, and perfectly accessible. All output must be delivered exclusively in the language I specify. Please provide a concise, simple, and crystal-clear ELI5 explanation of the following, rendered entirely in {language}: {highlight}.",
         },
         grammar = {
-            text = "Grammar",
+            text = _("Grammar"),
             order = 170,
+            desc = _("This prompt analyzes the grammar of the highlighted text, providing a detailed explanation of its structure and any grammatical errors."),
             system_prompt = "You are a helpful AI assistant. Always respond in Markdown format, but use markdown lists to present comparisons instead of tables.",
             user_prompt = "You are a meticulous and highly knowledgeable Grammar Expert with an encyclopedic understanding of syntax, morphology, punctuation, and linguistic structures across various languages. When presented with a text, your expertise lies in thoroughly dissecting its grammatical composition and providing a comprehensive, insightful explanation. Your task is to analyze the provided text, elucidating its sentence structures, parts of speech, verb tenses, clause relationships, and any other relevant grammatical elements. If present, you should also identify and clearly explain any grammatical errors, along with their corrections and the underlying rules. Your explanation should be didactic, detailed, and easy to understand, formatted clearly to highlight specific points. All explanations must be rendered exclusively in the language I specify. Please provide a detailed and comprehensive explanation of the grammar of the following text, rendered entirely in {language}: {highlight}",
         },
         vocabulary = {
-            text = "Vocabulary",
+            text = _("Vocabulary"),
             order = 180,
+            desc = _("This prompt analyzes the vocabulary of the highlighted text, identifying complex words and providing definitions, synonyms, and usage examples."),
             user_prompt = [[**Your Task:** Analyze the Input Text below. Find words/phrases that are B2 level or higher. Ignore common words (B1 level) and proper nouns.
 
                             **Output Requirements:**
@@ -113,10 +124,11 @@ Please provide a concise and clear summary of the following text in its own lang
                             **Input Text:** {highlight} ]], 
         },
         wikipedia = {
-            text = "Wikipedia",
+            text = _("Wikipedia"),
             order = 190,
+            desc = _("This prompt generates a comprehensive Wikipedia-style article based on the highlighted text, ensuring factual accuracy and neutrality."),
             user_prompt = "You are an exceptionally thorough and objective Informative Assistant designed to emulate the structure and content quality of a Wikipedia page. Your extensive knowledge base allows you to act as a definitive source for factual and unbiased information. When I provide you with a topic, your core task is to research and synthesize the most critical and universally accepted information about that subject. You must then present this information in the comprehensive, encyclopedic format of a Wikipedia article. Begin with a concise, overview introductory paragraph that defines the topic and summarizes its essence. Subsequently, elaborate on the most important facets, key historical events, fundamental concepts, or significant applications, ensuring every piece of information is factual, neutral, and devoid of opinion. All content generated should strictly adhere to Wikipedia's tone and style, and the entire response must be delivered exclusively in the language I specify. Please act as a Wikipedia page for the following topic, starting with an introductory paragraph and thoroughly covering its most important aspects, delivered entirely in {language}: {highlight}",
-    }
+        },
 }
 
 
@@ -238,7 +250,7 @@ M.getSortedCustomPrompts = function(filter_func)
     for prompt_index, prompt in pairs(M.merged_prompts) do
         -- Only add the prompt if there is no filter, or if the filter function returns true.
         if not filter_func or filter_func(prompt, prompt_index) == true then
-            table.insert(sorted_prompts, {idx = prompt_index, order = prompt.order or 1000, text = prompt.text or prompt_index})
+            table.insert(sorted_prompts, {idx = prompt_index, order = prompt.order or 1000, text = prompt.text or prompt_index, desc = prompt.desc or ""})
         end
     end
     table_sort(sorted_prompts, "order")

--- a/prompts.lua
+++ b/prompts.lua
@@ -232,7 +232,7 @@ M.getSortedCustomPrompts = function(filter_func)
     local sorted_prompts = {}
     for prompt_index, prompt in pairs(M.merged_prompts) do
         -- Only add the prompt if there is no filter, or if the filter function returns true.
-        if not filter_func or filter_func(prompt) == true then
+        if not filter_func or filter_func(prompt, prompt_index) == true then
             table.insert(sorted_prompts, {idx = prompt_index, order = prompt.order or 1000, text = prompt.text or prompt_index})
         end
     end


### PR DESCRIPTION
Introcduce hold action to the prompt buttons in the Assitant dialog. A confirm box shows a prompt function descrition and ask whether to add or remove the button from the main popup.

this feature depreciate the `show_on_main_popup = true` switch in the configuration file (stills works, but the user action config has priority.). also depreciate the `show_dictionary_button_in_main_popup` switch.

make the `dictionary_translate_to` optional, will use `response_language` by default.

<img width="312" height="368" alt="image" src="https://github.com/user-attachments/assets/9fc7d472-1718-4546-85f9-48cf0421c7b1" />

