### PR TITLE
AI response follow UI language as default

### DIFF
--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -134,13 +134,13 @@ local CONFIGURATION = {
 
     -- Optional features 
     features = {
-        response_language = "Turkish", --  Set language for the other responses, nil to English response. 
-        -- dictionary_translate_to = "Turkish", -- if you want the language of the dictionary to be different from the response language, set it here.
+        -- response_language = "Turkish", --  Set language for all AI responses, unset to use the UI language.
+        -- dictionary_translate_to = "Deutsch", -- Set the dictionary response language, unset to follow the `response_language`.
         hide_highlighted_text = false,  -- Set to true to hide the highlighted text at the top
         hide_long_highlights = true,    -- Hide highlighted text if longer than threshold
         long_highlight_threshold = 500,  -- Number of characters considered "long"
         max_display_user_prompt_length = 100,  -- Maximum number of characters of user_prompt to show in result window  (0 or nil for no limit)
-        system_prompt = "You are a helpful AI assistant. Always respond in Markdown format.", -- Custom system prompt for the AI ("Ask" button) to override the default, to disable set to nil
+        -- system_prompt = "You are a helpful AI assistant. Always respond in Markdown format.", -- Custom system prompt for the AI ("Ask" button) to override the default, to disable set to nil
         show_dictionary_button_in_dictionary_popup = true, -- Set to true to show the Dictionary (AI) button in the dictionary popup
         enable_AI_recap = true, -- Set to true to allow for a popup on a book you haven't read in a while to give you a quick AI recap
         render_markdown = true, -- Set to true to render markdown in the AI responses

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -54,7 +54,7 @@ function AssitantDialog:_formatUserPrompt(user_prompt, highlightedText)
   
   -- Handle case where no text is highlighted (gesture-triggered)
   local text_to_use = highlightedText and highlightedText ~= "" and highlightedText or ""
-  local language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language) or "English"
+  local language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language) or self.assitant:getUILanguage()
   
   -- replace placeholders in the user prompt
   return user_prompt:gsub("{(%w+)}", {

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -6,7 +6,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local _ = require("owngettext")
 local Event = require("ui/event")
-local configuration = require("configuration")
+local CONFIGURATION = require("CONFIGURATION")
 local dict_prompts = require("prompts").assitant_prompts.dict
 
 local function showDictionaryDialog(assitant, highlightedText, message_history)
@@ -114,14 +114,16 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
         end
     end
     
-    local dict_language = configuration.features.dictionary_translate_to or configuration.features.response_language or "English"
+    local resp_language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language) or self.assitant:getUILanguage()
+    local dict_language = CONFIGURATION.features.dictionary_translate_to or resp_language
     local context_message = {
         role = "user",
         content = string.gsub(dict_prompts.user_prompt, "{(%w+)}", {
-    language = dict_language,
-    context = prev_context .. highlightedText .. next_context,
-    word = highlightedText
-    })}
+                language = dict_language,
+                context = prev_context .. highlightedText .. next_context,
+                word = highlightedText
+        })
+    }
 
     table.insert(message_history, context_message)
 
@@ -134,7 +136,7 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
 
     local function createResultText(highlightedText, answer)
         local result_text
-        if configuration and configuration.features and (configuration.features.render_markdown or configuration.features.render_markdown == nil) then
+        if CONFIGURATION and CONFIGURATION.features and (CONFIGURATION.features.render_markdown or CONFIGURATION.features.render_markdown == nil) then
         -- in markdown mode, outputs markdown formated highlighted text
         result_text = "... " .. prev_context .. " **" .. highlightedText ..  "** " ..  next_context ..  " ...\n\n" ..  answer
         else

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -10,6 +10,8 @@ local logger = require("logger")
 local json = require("json")
 local ffi = require("ffi")
 local ffiutil = require("ffi/util")
+local Device = require("device")
+local Screen = Device.screen
 
 local Querier = {
     assitant = nil, -- reference to the main assistant object
@@ -138,6 +140,7 @@ function Querier:query(message_history, title)
     if type(res) == "function" then
         local streamDialog = InputDialog:new{
             face = Font:getFace("smallffont"),
+            width = Screen:getWidth() - Screen:scaleBySize(30),
             title = _("AI Responding"),
             description = string.format(
                 _("☁ %s/%s"), self.provider_name, self.provider_settings.model),

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -112,7 +112,7 @@ function Querier:query(message_history, title)
         return "", "Assitant: not configured."
     end
 
-    if self.settings:readSetting("forced_stream_mode") then
+    if self.settings:readSetting("forced_stream_mode", true) then -- defalut true
         if not self.provider_settings.additional_parameters then
             self.provider_settings.additional_parameters = {}
         end

--- a/main.lua
+++ b/main.lua
@@ -398,7 +398,7 @@ end
 function Assistant:applyOrRemoveTranslateOverride()
 
   local Translator = require("ui/translator")
-  local should_override = self.settings:readSetting("ai_translate_override")
+  local should_override = self.settings:readSetting("ai_translate_override", false)
 
   if should_override then
     -- Store original translate method if not already stored

--- a/main.lua
+++ b/main.lua
@@ -6,6 +6,7 @@ local Dispatcher = require("dispatcher")
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
 local Trapper = require("ui/trapper")
+local Language = require("ui/language")
 local LuaSettings = require("luasettings")
 local DataStorage = require("datastorage")
 local RadioButtonWidget = require("ui/widget/radiobuttonwidget")
@@ -397,9 +398,7 @@ end
 function Assistant:applyOrRemoveTranslateOverride()
 
   local Translator = require("ui/translator")
-
-  local should_override = CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language and
-      self.settings:readSetting("ai_translate_override")
+  local should_override = self.settings:readSetting("ai_translate_override")
 
   if should_override then
     -- Store original translate method if not already stored
@@ -441,6 +440,11 @@ function Assistant:applyOrRemoveTranslateOverride()
       logger.info("Assistant: translate method restored")
     end
   end
+end
+
+function Assistant:getUILanguage()
+  local language = G_reader_settings:readSetting("language") or "en"
+  return Language:getLanguageName(language) or "English"
 end
 
 return Assistant

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -6,7 +6,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local Event = require("ui/event")
 local _ = require("owngettext")
 local ChatGPTViewer = require("chatgptviewer")
-local configuration = require("configuration")
+local CONFIGURATION = require("CONFIGURATION")
 local recap_prompts = require("prompts").assitant_prompts.recap
 
 local function showRecapDialog(assitant, title, author, progress_percent, message_history)
@@ -22,11 +22,11 @@ local function showRecapDialog(assitant, title, author, progress_percent, messag
 
     local formatted_progress_percent = string.format("%.2f", progress_percent * 100)
     
-    -- Get recap configuration with fallbacks
-    local recap_config = configuration.features and configuration.features.recap_config or {}
+    -- Get recap CONFIGURATION with fallbacks
+    local recap_config = CONFIGURATION.features and CONFIGURATION.features.recap_config or {}
     local system_prompt = recap_config.system_prompt or recap_prompts.system_prompt
     local user_prompt_template = recap_config.user_prompt or recap_prompts.user_prompt
-    local language = configuration.features and configuration.features.response_language or "English"
+    local language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language) or self.assitant:getUILanguage()
     
     local message_history = message_history or {
         {

--- a/settingsdialog.lua
+++ b/settingsdialog.lua
@@ -51,10 +51,12 @@ function SettingsDialog:init()
         {
             key = "forced_stream_mode",
             text = _("Always use stream mode"),
+            checked = self.settings:readSetting("forced_stream_mode", true),
         },
         {
             key = "ai_translate_override",
             text = _("Use AI Assistant for 'Translate'"),
+            checked = self.settings:readSetting("ai_translate_override", false),
             changed_callback = function(checked)
                 self.assitant:applyOrRemoveTranslateOverride()
                 UIManager:show(InfoMessage:new{
@@ -166,7 +168,7 @@ function SettingsDialog:init()
         self.check_buttons[btn.key] = CheckButton:new{
             text = btn.text,
             face = Font:getFace("cfont", 18),
-            checked = self.settings:readSetting(btn.key, false),
+            checked = btn.checked,
             parent = self,
         }
         self:addWidget(self.check_buttons[btn.key])


### PR DESCRIPTION
- `response_language` in the configuration is now optional, it would be more friendly to just use the UI language to respond
- user prefers other wise can also set the `response_language`
- `forced_stream_mode` defaults to true
- `ai_translate_override` defaults to false
- stream dialog size adjust