### PR TITLE
Add setting menu for language and font size

### DIFF
--- a/api_handlers/base.lua
+++ b/api_handlers/base.lua
@@ -154,7 +154,7 @@ function BaseHandler:backgroudRequest(url, headers, body)
         local code, headers, status = socket.skip(1, http.request(request)) -- skip the first return value
         if code ~= 200 then -- non-200 response code, write error to pipe
             logger.warn("Background request non-200:", code, "status:", status, "url:", url)
-            ffiutil.writeToFD(child_write_fd, string.format("\r\n%s [%s %s] URL:%s\n\n", self.PROTOCAL_NON_200, status, code, url))  -- write end of response
+            ffiutil.writeToFD(child_write_fd, string.format("\r\n%s [%s %s] URL:%s\n\n", self.PROTOCAL_NON_200, status or "", code or "", url))  -- write end of response
         end
         ffi.C.close(child_write_fd)  -- close the write end of the pipe
     end

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -107,7 +107,6 @@ local ChatGPTViewer = InputContainer:extend {
   auto_para_direction = true,
   alignment_strict = false,
   render_markdown = true, -- converts markdown to HTML and displays the HTML
-  markdown_font_size = 20,
 
   title_face = nil,               -- use default from TitleBar
   title_multilines = nil,         -- see TitleBar for details
@@ -427,7 +426,6 @@ function ChatGPTViewer:init()
   end
 
   if self.render_markdown then
-    self.markdown_font_size = self.assistant.settings:readSetting("markdown_font_size", 20)
     -- Convert Markdown to HTML and render in a ScrollHtmlWidget
     local html_body, err = MD(self.text, {})
     if err then
@@ -438,7 +436,7 @@ function ChatGPTViewer:init()
     self.scroll_text_w = ScrollHtmlWidget:new {
       html_body = html_body,
       css = VIEWER_CSS,
-      default_font_size = Screen:scaleBySize(self.markdown_font_size),
+      default_font_size = Screen:scaleBySize(self.assistant.settings:readSetting("response_font_size", 20)),
       width = self.width - 2 * self.text_padding - 2 * self.text_margin,
       height = textw_height - 2 * self.text_padding - 2 * self.text_margin,
       dialog = self,
@@ -810,7 +808,7 @@ function ChatGPTViewer:update(new_text)
       self.scroll_text_w = ScrollHtmlWidget:new {
         html_body = html_body,
         css = VIEWER_CSS,
-        default_font_size = Screen:scaleBySize(self.markdown_font_size),
+        default_font_size = Screen:scaleBySize(self.assistant.settings:readSetting("response_font_size", 20)),
         width = self.width - 2 * self.text_padding - 2 * self.text_margin,
         height = self.textw:getSize().h - 2 * self.text_padding - 2 * self.text_margin,
         dialog = self,

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -427,6 +427,7 @@ function ChatGPTViewer:init()
   end
 
   if self.render_markdown then
+    self.markdown_font_size = self.assistant.settings:readSetting("markdown_font_size", 20)
     -- Convert Markdown to HTML and render in a ScrollHtmlWidget
     local html_body, err = MD(self.text, {})
     if err then

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -87,12 +87,12 @@ table td, table th {
 }
 ]]
 
-local RTL_CSS = [[  
+local RTL_CSS = [[
 body {
-    direction: rtl !important;   
-    text-align: right !important;  
-}  
-]]  
+    direction: rtl !important;
+    text-align: right !important;
+}
+]]
 
 local ChatGPTViewer = InputContainer:extend {
   title = nil,
@@ -816,7 +816,7 @@ function ChatGPTViewer:update(new_text)
       self.scroll_text_w = ScrollHtmlWidget:new {
         html_body = html_body,
         css = css,
-        default_font_size = Screen:scaleBySize(self.assistant.settings:readSetting("response_font_size", 20)),
+        default_font_size = Screen:scaleBySize(self.assistant.settings:readSetting("response_font_size") or 20),
         width = self.width - 2 * self.text_padding - 2 * self.text_margin,
         height = self.textw:getSize().h - 2 * self.text_padding - 2 * self.text_margin,
         dialog = self,

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -44,7 +44,6 @@ local Prompts = require("prompts")
 local VIEWER_CSS = [[
 @page {
     margin: 0;
-    font-family: 'Noto Sans';
 }
 
 body {
@@ -87,6 +86,13 @@ table td, table th {
     padding: 0;
 }
 ]]
+
+local RTL_CSS = [[  
+body {
+    direction: rtl !important;   
+    text-align: right !important;  
+}  
+]]  
 
 local ChatGPTViewer = InputContainer:extend {
   title = nil,
@@ -433,10 +439,11 @@ function ChatGPTViewer:init()
       -- Fallback to plain text if HTML generation fails
       html_body = self.text or "Missing text."
     end
+    local css = VIEWER_CSS .. ((self.assistant.settings:readSetting("response_is_rtl") or false) and RTL_CSS or "")
     self.scroll_text_w = ScrollHtmlWidget:new {
       html_body = html_body,
-      css = VIEWER_CSS,
-      default_font_size = Screen:scaleBySize(self.assistant.settings:readSetting("response_font_size", 20)),
+      css = css,
+      default_font_size = Screen:scaleBySize(self.assistant.settings:readSetting("response_font_size") or 20),
       width = self.width - 2 * self.text_padding - 2 * self.text_margin,
       height = textw_height - 2 * self.text_padding - 2 * self.text_margin,
       dialog = self,
@@ -805,9 +812,10 @@ function ChatGPTViewer:update(new_text)
         -- Fallback to plain text if HTML generation fails
         html_body = self.text or "Missing text."
       end
+      local css = VIEWER_CSS .. ((self.assistant.settings:readSetting("response_is_rtl") or false) and RTL_CSS or "")
       self.scroll_text_w = ScrollHtmlWidget:new {
         html_body = html_body,
-        css = VIEWER_CSS,
+        css = css,
         default_font_size = Screen:scaleBySize(self.assistant.settings:readSetting("response_font_size", 20)),
         width = self.width - 2 * self.text_padding - 2 * self.text_margin,
         height = self.textw:getSize().h - 2 * self.text_padding - 2 * self.text_margin,

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -134,15 +134,12 @@ local CONFIGURATION = {
 
     -- Optional features 
     features = {
-        -- response_language = "Turkish", --  Set language for all AI responses, unset to use the UI language.
-        -- dictionary_translate_to = "Deutsch", -- Set the dictionary response language, unset to follow the `response_language`.
         hide_highlighted_text = false,  -- Set to true to hide the highlighted text at the top
         hide_long_highlights = true,    -- Hide highlighted text if longer than threshold
         long_highlight_threshold = 500,  -- Number of characters considered "long"
         max_display_user_prompt_length = 100,  -- Maximum number of characters of user_prompt to show in result window  (0 or nil for no limit)
         -- system_prompt = "You are a helpful AI assistant. Always respond in Markdown format.", -- Custom system prompt for the AI ("Ask" button) to override the default, to disable set to nil
         render_markdown = true, -- Set to true to render markdown in the AI responses
-        markdown_font_size = 20, -- Default normal text font size of rendered markdown.
         updater_disabled = false, -- Set to true to disable update check.
 
         -- These are prompts defined in `prompts.lua`, can be overriden here.

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -5,6 +5,7 @@ local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Event = require("ui/event")
+local Font = require("ui/font")
 local _ = require("owngettext")
 local T = require("ffi/util").template
 local Trapper = require("ui/trapper")
@@ -146,6 +147,7 @@ function AssistantDialog:_createAndShowViewer(highlightedText, message_history, 
   local chatgpt_viewer = ChatGPTViewer:new {
     title = title,
     text = result_text,
+    text_face = Font:getFace("infofont", self.assistant.settings:readSetting("response_font_size", 20)),
     assistant = self.assistant,
     ui = self.assistant.ui,
     onAskQuestion = function(viewer, user_question) -- callback for user entered question

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -147,7 +147,7 @@ function AssistantDialog:_createAndShowViewer(highlightedText, message_history, 
   local chatgpt_viewer = ChatGPTViewer:new {
     title = title,
     text = result_text,
-    text_face = Font:getFace("infofont", self.assistant.settings:readSetting("response_font_size", 20)),
+    text_face = Font:getFace("infofont", self.assistant.settings:readSetting("response_font_size") or 20),
     assistant = self.assistant,
     ui = self.assistant.ui,
     onAskQuestion = function(viewer, user_question) -- callback for user entered question

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -59,7 +59,7 @@ function AssistantDialog:_formatUserPrompt(user_prompt, highlightedText)
   
   -- Handle case where no text is highlighted (gesture-triggered)
   local text_to_use = highlightedText and highlightedText ~= "" and highlightedText or ""
-  local language = self.settings:readSetting("response_language") or self.assistant.ui_language
+  local language = self.assistant.settings:readSetting("response_language") or self.assistant.ui_language
   
   -- replace placeholders in the user prompt
   return user_prompt:gsub("{(%w+)}", {

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -59,7 +59,7 @@ function AssistantDialog:_formatUserPrompt(user_prompt, highlightedText)
   
   -- Handle case where no text is highlighted (gesture-triggered)
   local text_to_use = highlightedText and highlightedText ~= "" and highlightedText or ""
-  local language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language) or self.assistant.ui_language
+  local language = self.settings:readSetting("response_language") or self.assistant.ui_language
   
   -- replace placeholders in the user prompt
   return user_prompt:gsub("{(%w+)}", {
@@ -142,7 +142,6 @@ function AssistantDialog:_createAndShowViewer(highlightedText, message_history, 
   local CONFIGURATION = self.CONFIGURATION
   local result_text = self:_createResultText(highlightedText, message_history, nil, title)
   local render_markdown = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.render_markdown) or true
-  local markdown_font_size = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.markdown_font_size) or 20
   
   local chatgpt_viewer = ChatGPTViewer:new {
     title = title,
@@ -193,7 +192,6 @@ function AssistantDialog:_createAndShowViewer(highlightedText, message_history, 
     highlighted_text = highlightedText,
     message_history = message_history,
     render_markdown = render_markdown,
-    markdown_font_size = markdown_font_size,
   }
   
   UIManager:show(chatgpt_viewer)

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -114,8 +114,7 @@ local function showDictionaryDialog(assistant, highlightedText, message_history)
         end
     end
     
-    local resp_language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language) or assistant.ui_language
-    local dict_language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.dictionary_translate_to) or resp_language
+    local dict_language = assistant.settings:readSetting("response_language") or assistant.ui_language
     local context_message = {
         role = "user",
         content = string.gsub(dict_prompts.user_prompt, "{(%w+)}", {

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -140,7 +140,7 @@ function Querier:query(message_history, title)
             description = string.format(
                 _("☁ %s/%s"), self.provider_name, self.provider_settings.model),
             inputtext_class = StreamText, -- use our custom InputText class
-            input_face = Font:getFace("infofont", self.settings:readSetting("markdown_font_size", 20)),
+            input_face = Font:getFace("infofont", self.settings:readSetting("response_font_size", 20)),
             title_bar_left_icon = "appbar.settings",
             title_bar_left_icon_tap_callback = function ()
                 self.assistant:showSettings()

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -177,7 +177,7 @@ function Querier:query(message_history, title)
         end
 
         if err then
-            return nil, err
+            return nil, err:gsub("^[\n%s]*", "") -- clean leading spaces and newlines
         end
 
         res = content

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -140,7 +140,7 @@ function Querier:query(message_history, title)
             description = string.format(
                 _("☁ %s/%s"), self.provider_name, self.provider_settings.model),
             inputtext_class = StreamText, -- use our custom InputText class
-            input_face = Font:getFace("infofont", self.settings:readSetting("response_font_size", 20)),
+            input_face = Font:getFace("infofont", self.settings:readSetting("response_font_size") or 20),
             title_bar_left_icon = "appbar.settings",
             title_bar_left_icon_tap_callback = function ()
                 self.assistant:showSettings()

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -135,7 +135,7 @@ function Querier:query(message_history, title)
     -- open a stream dialog and run the background query in a subprocess
     if type(res) == "function" then
         local streamDialog = InputDialog:new{
-            face = Font:getFace("smallffont"),
+            face = Font:getFace("infofont", self.settings:readSetting("markdown_font_size", 20)),
             width = Screen:getWidth() - Screen:scaleBySize(30),
             title = _("AI is responding"),
             description = string.format(

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -135,12 +135,12 @@ function Querier:query(message_history, title)
     -- open a stream dialog and run the background query in a subprocess
     if type(res) == "function" then
         local streamDialog = InputDialog:new{
-            face = Font:getFace("infofont", self.settings:readSetting("markdown_font_size", 20)),
             width = Screen:getWidth() - Screen:scaleBySize(30),
             title = _("AI is responding"),
             description = string.format(
                 _("☁ %s/%s"), self.provider_name, self.provider_settings.model),
             inputtext_class = StreamText, -- use our custom InputText class
+            input_face = Font:getFace("infofont", self.settings:readSetting("markdown_font_size", 20)),
             title_bar_left_icon = "appbar.settings",
             title_bar_left_icon_tap_callback = function ()
                 self.assistant:showSettings()

--- a/recapdialog.lua
+++ b/recapdialog.lua
@@ -26,7 +26,7 @@ local function showRecapDialog(assistant, title, author, progress_percent, messa
     local recap_config = CONFIGURATION.features and CONFIGURATION.features.recap_config or {}
     local system_prompt = recap_config.system_prompt or recap_prompts.system_prompt
     local user_prompt_template = recap_config.user_prompt or recap_prompts.user_prompt
-    local language = (CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.response_language) or self.assistant.ui_language
+    local language = assistant.settings:readSetting("response_language") or assistant.ui_language
     
     local message_history = message_history or {
         {

--- a/settingsdialog.lua
+++ b/settingsdialog.lua
@@ -47,7 +47,6 @@ local SettingsDialog = InputDialog:extend{
     -- widgets
     buttons = nil,
     radio_buttons = nil,
-    check_buttons = {},
 
     title_bar_left_icon = "appbar.menu",
     title_bar_left_icon_tap_callback = nil,
@@ -64,7 +63,6 @@ function SettingsDialog:init()
 
     self.check_button_init_list = {
         {
-            key = "forced_stream_mode",
             text = _("Always enable stream response"),
             checked = self.settings:readSetting("forced_stream_mode", true),
             callback = function(btn) 
@@ -73,7 +71,6 @@ function SettingsDialog:init()
             end
         },
         {
-            key = "ai_translate_override",
             text = _("Use AI Assistant for 'Translate'"),
             checked = self.settings:readSetting("ai_translate_override", false),
             callback = function(btn) 
@@ -83,7 +80,6 @@ function SettingsDialog:init()
             end
         },
         {
-            key = "dict_popup_show_dictionary",
             text = _("Show Dictionary(AI) in Dictionary Popup"),
             checked = self.settings:readSetting("dict_popup_show_dictionary", true),
             callback = function(btn) 
@@ -92,7 +88,6 @@ function SettingsDialog:init()
             end
         },
         {
-            key = "dict_popup_show_wikipedia",
             text = _("Show Wikipedia(AI) in Dictionary Popup"),
             checked = self.settings:readSetting("dict_popup_show_wikipedia", true),
             callback = function(btn) 
@@ -101,7 +96,6 @@ function SettingsDialog:init()
             end
         },
         {
-            key = "auto_copy_asked_question",
             text = _("Copy entered question to the clipboard"),
             checked = self.settings:readSetting("auto_copy_asked_question", true),
             callback = function(btn) 
@@ -110,7 +104,6 @@ function SettingsDialog:init()
             end
         },
         {
-            key = "enable_recap",
             text = _("Enable AI Recap"),
             checked = self.settings:readSetting("enable_recap", false),
             callback = function(btn) 
@@ -221,15 +214,13 @@ function SettingsDialog:init()
     }
 
     for _, btn in ipairs(self.check_button_init_list) do
-        self.check_buttons[btn.key] = xCheckButton:new{
-            key = btn.key,
+        self:addWidget(xCheckButton:new{
             text = btn.text,
             face = Font:getFace("cfont", 18),
             checked = btn.checked,
             xcallback = btn.callback,
             parent = self,
-        }
-        self:addWidget(self.check_buttons[btn.key])
+        })
     end
 
     self.dialog_frame = FrameContainer:new{
@@ -329,6 +320,11 @@ function SettingsDialog:onShowMenu()
                                     for i, f in ipairs(langsetting.input_fields) do  
                                         f:setText("")  
                                     end  
+                                    if self._checkbtn_is_rtl then
+                                        self._checkbtn_is_rtl.checked = false
+                                        self._checkbtn_is_rtl:init()
+                                    end
+
                                     UIManager:setDirty(langsetting, function()  
                                         return "ui", langsetting.dialog_frame.dimen  
                                     end)  
@@ -356,6 +352,13 @@ function SettingsDialog:onShowMenu()
                                         end
                                     end
 
+                                    if self._checkbtn_is_rtl then
+                                        local checked = self._checkbtn_is_rtl.checked 
+                                        if checked ~= (self.assistant.settings:readSetting("response_is_rtl") or false) then
+                                            self.assistant.settings:saveSetting("response_is_rtl", checked)
+                                        end
+                                    end
+
                                     self.assistant.updated = true
                                     UIManager:close(langsetting)
                                 end
@@ -364,6 +367,20 @@ function SettingsDialog:onShowMenu()
                     },
 
                 }
+
+                self._checkbtn_is_rtl = CheckButton:new{
+                        text = "RTL written Language",
+                        face = Font:getFace("x_smallinfofont"),  
+                        checked = self.settings:readSetting("response_is_rtl") or false,
+                        parent = self,
+                }
+
+                langsetting:addWidget(FrameContainer:new{  
+                    padding = Size.padding.default,  
+                    margin = Size.margin.small,  
+                    bordersize = 0,  
+                    self._checkbtn_is_rtl,
+                })
 
                 if self.assistant.settings:has("dict_language") or
                     self.assistant.settings:has("response_language") then

--- a/settingsdialog.lua
+++ b/settingsdialog.lua
@@ -47,16 +47,11 @@ local SettingsDialog = InputDialog:extend{
     -- widgets
     buttons = nil,
     radio_buttons = nil,
-
-    title_bar_left_icon = "appbar.menu",
-    title_bar_left_icon_tap_callback = nil,
-    -- title_bar_left_icon_tap_callback = function ()
-    --     self:onShowMenu()
-    -- end,
 }
 
 function SettingsDialog:init()
 
+    self.title_bar_left_icon = "appbar.menu"
     self.title_bar_left_icon_tap_callback = function ()
         self:onShowMenu()
     end
@@ -317,17 +312,17 @@ function SettingsDialog:onShowMenu()
                             {
                                 text = _("Clear"),
                                 callback = function()
-                                    for i, f in ipairs(langsetting.input_fields) do  
-                                        f:setText("")  
-                                    end  
+                                    for i, f in ipairs(langsetting.input_fields) do
+                                        f:setText("")
+                                    end
                                     if self._checkbtn_is_rtl then
                                         self._checkbtn_is_rtl.checked = false
                                         self._checkbtn_is_rtl:init()
                                     end
 
-                                    UIManager:setDirty(langsetting, function()  
-                                        return "ui", langsetting.dialog_frame.dimen  
-                                    end)  
+                                    UIManager:setDirty(langsetting, function()
+                                        return "ui", langsetting.dialog_frame.dimen
+                                    end)
                                 end
                             },
                             {
@@ -353,7 +348,7 @@ function SettingsDialog:onShowMenu()
                                     end
 
                                     if self._checkbtn_is_rtl then
-                                        local checked = self._checkbtn_is_rtl.checked 
+                                        local checked = self._checkbtn_is_rtl.checked
                                         if checked ~= (self.assistant.settings:readSetting("response_is_rtl") or false) then
                                             self.assistant.settings:saveSetting("response_is_rtl", checked)
                                         end
@@ -369,13 +364,12 @@ function SettingsDialog:onShowMenu()
                 }
 
                 self._checkbtn_is_rtl = CheckButton:new{
-                        text = "RTL written Language",
+                        text = _("RTL written Language"),
                         face = Font:getFace("x_smallinfofont"),  
                         checked = self.settings:readSetting("response_is_rtl") or false,
                         parent = self,
                 }
-
-                langsetting:addWidget(FrameContainer:new{  
+                langsetting:addWidget(FrameContainer:new{
                     padding = Size.padding.default,  
                     margin = Size.margin.small,  
                     bordersize = 0,  
@@ -384,6 +378,7 @@ function SettingsDialog:onShowMenu()
 
                 if self.assistant.settings:has("dict_language") or
                     self.assistant.settings:has("response_language") then
+                    -- show a notice when fields filled
                     langsetting:addWidget(FrameContainer:new{  
                         padding = Size.padding.default,  
                         margin = Size.margin.small,  
@@ -392,7 +387,6 @@ function SettingsDialog:onShowMenu()
                             text = T(_("Leave these fields blank to use the UI language: %1"),  self.assistant.ui_language),
                             face = Font:getFace("x_smallinfofont"),  
                             width = math.floor(langsetting.width * 0.95),  
-                            -- width = langsetting.width,
                         }
                     })
                 end

--- a/settingsdialog.lua
+++ b/settingsdialog.lua
@@ -326,24 +326,15 @@ function SettingsDialog:onShowMenu()
                                 end
                             },
                             {
+                                id = "save",
                                 text = _("Save"),
-                                callback = function(touchmenu_instance)
+                                callback = function()
                                     local fields = langsetting:getFields()
-
-                                    if fields[1] ~= "" then
-                                        self.assistant.settings:saveSetting("response_language", fields[1])
-                                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                                    else
-                                        if self.assistant.settings:has("response_language") then
-                                            self.assistant.settings:delSetting("response_language")
-                                        end
-                                    end
-
-                                    if fields[2] ~= "" then
-                                        self.assistant.settings:saveSetting("dict_language", fields[2])
-                                    else
-                                        if self.assistant.settings:has("dict_language") then
-                                            self.assistant.settings:delSetting("dict_language")
+                                    for i, key in ipairs({"response_language", "dict_language"}) do
+                                        if fields[i] == "" then
+                                            self.assistant.settings:delSetting(key)
+                                        else
+                                            self.assistant.settings:saveSetting(key, fields[i])
                                         end
                                     end
 

--- a/settingsdialog.lua
+++ b/settingsdialog.lua
@@ -253,7 +253,7 @@ function SettingsDialog:init()
 end
 
 function SettingsDialog:onShowMenu()
-    local fontsize = self.assistant.settings:readSetting("markdown_font_size", 20)
+    local fontsize = self.assistant.settings:readSetting("response_font_size", 20)
     local dialog
     local buttons = {
         {{
@@ -272,7 +272,7 @@ function SettingsDialog:onShowMenu()
                     default_value = 20,
                     keep_shown_on_apply = true,
                     callback = function(spin)
-                        self.assistant.settings:saveSetting("markdown_font_size", spin.value)
+                        self.assistant.settings:saveSetting("response_font_size", spin.value)
                         self.assistant.updated = true
                     end,
                 }


### PR DESCRIPTION
- Adds a menu popup on the left top conner of settings dialog
- adjust response font size and language
- deprecated configs: `response_language` , `dictionary_translate_to`, `markdown_font_size`

<img width="220" height="260" alt="image" src="https://github.com/user-attachments/assets/bf5ef77c-d1a8-4ca0-aa35-79d77fb4a645" />
<img width="220" height="180" alt="image" src="https://github.com/user-attachments/assets/b75f6946-bfe4-4ee7-a127-31659d75df6d" />
