### PR TITLE
feat: setting purge button

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -255,7 +255,10 @@ On the result dialog to close (as the Close button is far to reach).
                 text = _("Purge Settings"),
                 callback = function()
                   UIManager:show(ConfirmBox:new{
-                    text = _("Are you sure to purge the assistant plugin settings? It may help when you encounter some issues. \n\nconfiguration.lua is safe, only the settings in the dialog are purged."),
+                    text = _([[Are you sure to purge the assistant plugin settings? 
+This resets the assistant plugin to the status the first time you installed it.
+
+configuration.lua is safe, only the settings in the dialog are purged.]]),
                     ok_text = _("Purge"),
                     ok_callback = function()
                       self.settings:reset({})


### PR DESCRIPTION
there was a tip infobox when HOLD on the AI Assistant button, now adds two more buttons:

- one more way to open the Setting Dialog
- purge the Setting user was done in the SettingDialog, resets everything as first intalling the pulgin.

<img width="250" height="360" alt="image" src="https://github.com/user-attachments/assets/ae5a7b27-d3f0-4a26-89dd-0dc65bc20de6" />
