### PR TITLE
feat: notebook file as conversation logs

### DIFF
--- a/assistant_settings.lua
+++ b/assistant_settings.lua
@@ -269,10 +269,10 @@ function SettingsDialog:init()
             end
         },
         {
-            text = _("Auto Export Conversations to File"),
-            checked = self.settings:readSetting("auto_export_conversations", false),
+            text = _("Auto-save conversations to NoteBook."),
+            checked = self.settings:readSetting("auto_save_to_notebook", false),
             callback = function()
-                self.settings:toggle("auto_export_conversations")
+                self.settings:toggle("auto_save_to_notebook")
                 self.assistant.updated = true
             end
         },

--- a/main.lua
+++ b/main.lua
@@ -14,6 +14,7 @@ local DataStorage = require("datastorage")
 local ConfirmBox  = require("ui/widget/confirmbox")
 local T 		      = require("ffi/util").template
 local FrontendUtil = require("util")
+local TextViewer = require("ui/widget/textviewer")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ffiutil = require("ffi/util")
 
@@ -153,6 +154,40 @@ function Assistant:addToMainMenu(menu_items)
               })
             end,
             separator = true,
+          },
+          {
+            text = _("NoteBook (Auto-Saved AI Conversations)"),
+            callback = function ()
+              local notebookfile = self.ui.bookinfo:getNotebookFile(self.ui.doc_settings)
+              UIManager:show(ConfirmBox:new{
+                text = _("Notebook file: \n\n") .. notebookfile,
+                ok_text = _("View"),
+                ok_callback = function() TextViewer.openFile(notebookfile) end,
+                other_buttons = {{
+                  {
+                    text = _("Delete"),
+                    callback = function ()
+                      UIManager:show(ConfirmBox:new{
+                        text = T(_("Delete file?\n%1\nThis operation is not reversible."), notebookfile),
+                        ok_text = _("Delete"),
+                        ok_callback = function ()
+                          local ok, err = FrontendUtil.removeFile(notebookfile)
+                          if not ok then
+                            UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
+                          end
+                        end
+                      })
+                    end
+                  },
+                  {
+                    text = _("Edit"),
+                    callback = function ()
+                      UIManager:broadcastEvent(Event:new("ShowNotebookFile"))
+                    end
+                  },
+              }}
+              })
+            end,
           },
           {
             text = _("AI Assistant Settings"),


### PR DESCRIPTION
Some adjust to the "Export Conversations to File" featue.

KOReader has an unnoticiable feature: notebook ( top right button menu-> Book Info -> 2nd Page -> NoteBook file), which can be used to store AI conversations. By using the `BookInfo` module we can CRUD on the AI conversation easily.

- the default location of notebook file is a `.txt` along side with the ebook file
- can be changed location in BookInfo model
- Edit / View the txt file from the menu

<img width="426" height="318" alt="image" src="https://github.com/user-attachments/assets/8642e2f4-1474-4cb7-b9fb-514bdf068e89" />

<img width="396" height="267" alt="image" src="https://github.com/user-attachments/assets/11a70b5d-3001-41c6-90ad-494333d6119b" />
