### PR TITLE
fix: change version number to string to preserve trailing zero

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -3,5 +3,5 @@ return {
     name = "assistant",
     fullname = _("AI Assistant"),
     description = _("💡 Enhance your KOReader experience with AI"),
-    version = 1.10,
+    version = "1.10",
 }


### PR DESCRIPTION
Before | After
-- | --
<img width="872" height="366" alt="image" src="https://github.com/user-attachments/assets/0fd2c6d6-b5e0-44f0-88c2-79256972d93e" /> | <img width="1062" height="350" alt="image" src="https://github.com/user-attachments/assets/cf35e3dc-524b-40d6-a2e6-6b6fd086f65f" />


</body>
</html>
