### PR TITLE
feat: suggested follow up question in HTML

### DIFF
--- a/assistant_prompts.lua
+++ b/assistant_prompts.lua
@@ -287,19 +287,19 @@ Ensure all information is accurate and based on known facts. Respond entirely in
     _("Word Origin"))
     },
     suggestions_prompt = [[  
-At the end of your response, generate **two questions in {language} language** that the user might find interesting based on your answer. 
+At the end of your response, generate **a few questions in {language} language** that the user might find interesting based on your answer. 
 Display them as a **Markdown unordered list** with this exact format:  
 ```
 ---
 
-{short_headline_in_language}
+{short_headline}
 
 - [Question 1](#suggested-question:Question 1)  
 - [Question 2](#suggested-question:Question 2)  
 ```  
 
 **Rules:**  
-1. Replace `{short_headline_in_language}` with a **natural phrase**: `You may find these topics interesting`, using {language} language.
+1. Replace `{short_headline}` with a **natural phrase**: `You may find these topics interesting:`, using {language} language.
 2. Leave an empty line before the list to follow strict markdown syntax.
 3. Use `-` as bullet points; never `*` or `+`.  
 4. Link syntax must be `[TEXT](#suggested-question:TEXT)` (colon `:` is required).  

--- a/assistant_prompts.lua
+++ b/assistant_prompts.lua
@@ -287,23 +287,7 @@ Ensure all information is accurate and based on known facts. Respond entirely in
     _("Word Origin"))
     },
     suggestions_prompt = [[  
-At the end of your response, generate **a few questions in {language} language** that the user might find interesting based on your answer. 
-Display them as a **Markdown unordered list** with this exact format:  
-```
----
-
-{short_headline}
-
-- [Question 1](#suggested-question:Question 1)  
-- [Question 2](#suggested-question:Question 2)  
-```  
-
-**Rules:**  
-1. Replace `{short_headline}` with a **natural phrase**: `You may find these topics interesting:`, using {language} language.
-2. Leave an empty line before the list to follow strict markdown syntax.
-3. Use `-` as bullet points; never `*` or `+`.  
-4. Link syntax must be `[TEXT](#suggested-question:TEXT)` (colon `:` is required).  
-5. Avoid using parentheses `()` within the question text.
+Generate 2-3 {language} questions at the end. Use Markdown: `---`, then **translate "You may find these topics interesting:" into {language}** (empty line after), then `- [Question](#suggested-question:Question)` list. No `()` in questions.
 ]]
 }
 

--- a/assistant_prompts.lua
+++ b/assistant_prompts.lua
@@ -303,7 +303,7 @@ Display them as a **Markdown unordered list** with this exact format:
 2. Leave an empty line before the list to follow strict markdown syntax.
 3. Use `-` as bullet points; never `*` or `+`.  
 4. Link syntax must be `[TEXT](#suggested-question:TEXT)` (colon `:` is required).  
-5. No markdown headers (`##`) are allowed.  
+5. Avoid using parentheses `()` within the question text.
 ]]
 }
 

--- a/assistant_prompts.lua
+++ b/assistant_prompts.lua
@@ -287,11 +287,23 @@ Ensure all information is accurate and based on known facts. Respond entirely in
     _("Word Origin"))
     },
     suggestions_prompt = [[  
-At the end of the response, generate two questions in {language} that the user might find interesting based on your response.
-Each suggestion must:  
-1. Be enclosed in XML tags `<SUGGESTION></SUGGESTION>`.  
-2. **Stand alone on a separate line** (do not merge with other text).  
-3. Avoid adding prefixes like `##`, `###`, or any heading symbols.  
+At the end of your response, generate **two questions in {language} language** that the user might find interesting based on your answer. 
+Display them as a **Markdown unordered list** with this exact format:  
+```
+---
+
+{short_headline_in_language}
+
+- [Question 1](#suggested-question:Question 1)  
+- [Question 2](#suggested-question:Question 2)  
+```  
+
+**Rules:**  
+1. Replace `{short_headline_in_language}` with a **natural phrase**: `You may find these topics interesting`, using {language} language.
+2. Leave an empty line before the list to follow strict markdown syntax.
+3. Use `-` as bullet points; never `*` or `+`.  
+4. Link syntax must be `[TEXT](#suggested-question:TEXT)` (colon `:` is required).  
+5. No markdown headers (`##`) are allowed.  
 ]]
 }
 

--- a/assistant_settings.lua
+++ b/assistant_settings.lua
@@ -222,7 +222,7 @@ function SettingsDialog:init()
             end
         },
         {
-            text = _("Enable Suggested Questions from AI"),
+            text = _("Show Related Questions from AI"),
             checked = self.settings:readSetting("auto_prompt_suggest", false),
             callback = function()
                 self.settings:toggle("auto_prompt_suggest")

--- a/assistant_viewer.lua
+++ b/assistant_viewer.lua
@@ -930,10 +930,10 @@ function ChatGPTViewer:trimMessageHistory()
 end
 
 function ChatGPTViewer:html_link_tapped_callback(link)
-  if util.stringStartsWith(link.uri, "#suggested-question:") then
-    local question = link.uri:sub(21) -- remove prefix `#suggested-question:`
-    self:askAnotherQuestion(true)
-    self.input_dialog:setInputText(question, nil, false)
+  local SUGGESTION_PREFIX = "#suggested-question:"
+  if link.uri and util.stringStartsWith(link.uri, SUGGESTION_PREFIX) then
+    self:askAnotherQuestion(true) -- simple_mode
+    self.input_dialog:setInputText(link.uri:sub(#SUGGESTION_PREFIX+1), nil, false)
   end
 end
 

--- a/assistant_viewer.lua
+++ b/assistant_viewer.lua
@@ -85,10 +85,6 @@ table td, table th {
     border: 1px solid black;
     padding: 0;
 }
-
-SUGGESTION {
-    display: none;
-}
 ]]
 
 local RTL_CSS = [[


### PR DESCRIPTION
The suggested follow up question feature has been redesigned.

Instead of buttons, now use clickable HTML links within the text itself. Clicking these links will show Ask another question. This makes it more flexible and ensures each step's questions stay visible and don't get covered up.

![clickable HTML links](https://github.com/user-attachments/assets/654ff647-f5db-499b-97d0-32ca08013975)