### PR TITLE
fix: Strip trailing carriage return for Windows CRLF line endings

### DIFF
--- a/assistant_gettext.lua
+++ b/assistant_gettext.lua
@@ -197,6 +197,10 @@ function GetText_mt.__index.changeLang(new_lang)
     local what = nil
     while true do
         local line = po:read("*l")
+        -- Strip trailing carriage return for Windows CRLF line endings
+        if line then
+            line = line:gsub("\r$", "")
+        end
         if line == nil or line == "" then
             if data.msgid and data.msgid_plural and data["msgstr[0]"] then
                 for k, v in pairs(data) do


### PR DESCRIPTION
### Problem

`.po` files  with Windows CRLF line endings (`\r\n`) were not being parsed correctly on Linux/Android. When reading with `po:read("*l")`, only `\n` is stripped, leaving `\r` at the end of each line.

This caused:
- The parsing loop to never recognize translation entry boundaries, so translations are not loaded correctly.
- All menu text remaining in English even when KOReader was set to a different language.

### Solution

Added `line:gsub("\r$", "")` to strip trailing carriage returns after reading each line, ensuring cross-platform compatibility with [.po](cci:7://file:///c:/Users/-GALACTUS-/Documents/GitHub/KOReader/assistant.koplugin/l10n/zh_CN/koreader.po:0:0-0:0) files regardless of line ending style.

### Testing

Tested on Android with `zh_CN` locale - all translations now load correctly and menu items display in the expected target language.