### PR TITLE
Fix invalid unicode error when using book context

### DIFF
--- a/assistant_utils.lua
+++ b/assistant_utils.lua
@@ -6,19 +6,6 @@ local T = require("ffi/util").template
 local koutil = require("util")
 local _ = require("assistant_gettext")
 
-local function getGeneralNotebookFilePath(assistant)
-  local notebookfile = nil
-  local default_folder = util.tableGetValue(assistant.CONFIGURATION, "features", "default_folder_for_logs")
-  local home_dir = G_reader_settings:readSetting("home_dir")
-  local current_dir = assistant.ui.file_chooser and assistant.ui.file_chooser.path or assistant.ui:getLastDirFile()
-  local target_dir = default_folder and default_folder ~= "" and util.pathExists(default_folder) and default_folder or (home_dir or current_dir)
-  if target_dir then
-    local notebookfile_path = target_dir .. "/general_notebook.md"
-    notebookfile = notebookfile_path
-  end
-  return notebookfile
-end
-
 local function extractBookTextForAnalysis(CONFIGURATION, ui)
     local book_text = nil
       if not ui.document.info.has_pages then
@@ -31,6 +18,7 @@ local function extractBookTextForAnalysis(CONFIGURATION, ui)
           local max_text_length_for_analysis = koutil.tableGetValue(CONFIGURATION, "features", "max_text_length_for_analysis") or 100000
           if #book_text > max_text_length_for_analysis then
               book_text = book_text:sub(-max_text_length_for_analysis)
+              book_text = book_text:gsub("^[\128-\191]+", "")
           end
       else
         -- Extract text from the last n pages up to current reading position for page-based documents
@@ -60,6 +48,10 @@ local function extractBookTextForAnalysis(CONFIGURATION, ui)
         local max_text_length_for_analysis = koutil.tableGetValue(CONFIGURATION, "features", "max_text_length_for_analysis") or 100000
         if #book_text > max_text_length_for_analysis then
             book_text = book_text:sub(-max_text_length_for_analysis)
+            book_text = book_text:gsub("^[\128-\191]+", "")
+        end
+        if book_text then
+            book_text = book_text:gsub("[%z\1-\8\11\12\14-\31]", "")
         end
     end
     return book_text
@@ -118,6 +110,7 @@ local function extractHighlightsNotesAndNotebook(CONFIGURATION, ui, include_note
     local max_text_length_for_analysis = koutil.tableGetValue(CONFIGURATION, "features", "max_text_length_for_analysis") or 100000
     if #combined > max_text_length_for_analysis then
         combined = combined:sub(-max_text_length_for_analysis)
+        combined = combined:gsub("^[\128-\191]+", "")
     end
     
     return combined
@@ -128,7 +121,7 @@ local function getPageInfo(ui)
   local percentage = 0
   local total_pages = nil
   local chapter_title = nil
-  if ui.highlight and ui.highlight.selected_text and ui.highlight.selected_text.pos0 then
+  if ui.highlight.selected_text and ui.highlight.selected_text.pos0 then
     if ui.paging then
       page_number = ui.highlight.selected_text.pos0.page
     else
@@ -165,50 +158,46 @@ local function saveToNotebookFile(assistant, log_entry)
   local success, err = pcall(function()
     local notebookfile = assistant.ui.bookinfo:getNotebookFile(assistant.ui.doc_settings)
     local default_folder = util.tableGetValue(assistant.CONFIGURATION, "features", "default_folder_for_logs")
-    if assistant.ui.doc_settings then
-      if default_folder and default_folder ~= "" then
-        if not notebookfile:find("^" .. default_folder:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")) then
-          if not util.pathExists(default_folder) then
-            UIManager:show(InfoMessage:new{
-                icon = "notice-warning",
-                text = T(_("Cannot access default folder for logs: %1\nUsing original location."), default_folder),
-                timeout = 5,
-              })
+    if default_folder and default_folder ~= "" then
+      if not notebookfile:find("^" .. default_folder:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")) then
+        if not util.pathExists(default_folder) then
+          UIManager:show(InfoMessage:new{
+              icon = "notice-warning",
+              text = T(_("Cannot access default folder for logs: %1\nUsing original location."), default_folder),
+              timeout = 5,
+            })
+        else
+          local original_filename = notebookfile:match("([^/\\]+)$")
+          if original_filename then
+            original_filename = original_filename:gsub("%.[^.]*$", ".md")
           else
-            local original_filename = notebookfile:match("([^/\\]+)$")
-            if original_filename then
-              original_filename = original_filename:gsub("%.[^.]*$", ".md")
-            else
-              local doc_path = assistant.ui.document.file
-              if doc_path then
-                local doc_filename = doc_path:match("([^/\\]+)$")
-                if doc_filename then
-                  original_filename = doc_filename..".md"
-                else
-                  original_filename = "notebook.md"
-                end
+            local doc_path = assistant.ui.document.file
+            if doc_path then
+              local doc_filename = doc_path:match("([^/\\]+)$")
+              if doc_filename then
+                original_filename = doc_filename..".md"
               else
                 original_filename = "notebook.md"
               end
+            else
+              original_filename = "notebook.md"
             end
-            local new_notebookfile = default_folder .. "/" .. original_filename
-
-            assistant.ui.doc_settings:saveSetting("notebook_file", new_notebookfile)
-
-            notebookfile = new_notebookfile
           end
-        end
-      end
+          local new_notebookfile = default_folder .. "/" .. original_filename
 
-      if notebookfile and not notebookfile:find("%.md$") then
-        notebookfile = notebookfile:gsub("%.[^.]*$", ".md")
-        if not notebookfile:find("%.md$") then
-          notebookfile = notebookfile .. ".md"
+          assistant.ui.doc_settings:saveSetting("notebook_file", new_notebookfile)
+
+          notebookfile = new_notebookfile
         end
-        assistant.ui.doc_settings:saveSetting("notebook_file", notebookfile)
       end
-    else
-      notebookfile = getGeneralNotebookFilePath(assistant)
+    end
+
+    if notebookfile and not notebookfile:find("%.md$") then
+      notebookfile = notebookfile:gsub("%.[^.]*$", ".md")
+      if not notebookfile:find("%.md$") then
+        notebookfile = notebookfile .. ".md"
+      end
+      assistant.ui.doc_settings:saveSetting("notebook_file", notebookfile)
     end
 
     if notebookfile then
@@ -232,99 +221,9 @@ local function saveToNotebookFile(assistant, log_entry)
   end
 end
 
-local function normalizeMarkdownHeadings(content, heading_offset, max_heading_level)
-  if type(content) ~= "string" or content == "" then
-    return content
-  end
-
-  heading_offset = tonumber(heading_offset) or 0
-  max_heading_level = tonumber(max_heading_level) or 6
-
-  if heading_offset <= 0 then
-    return content
-  end
-
-  local max_heading_level_found = nil
-  for line in content:gmatch("[^\n]+") do
-    local hashes = line:match("^%s*(#+)")
-    if hashes then
-      local level = #hashes
-      if not max_heading_level_found or level > max_heading_level_found then
-        max_heading_level_found = level
-      end
-    end
-  end
-
-  if not max_heading_level_found then
-    return content
-  end
-
-  local target_max_level = heading_offset + 1
-  local heading_shift = target_max_level - max_heading_level_found
-  if heading_shift <= 0 then
-    return content
-  end
-
-  local normalized_lines = {}
-  local start_index = 1
-  local content_length = #content
-  local has_trailing_newline = content:sub(-1) == "\n"
-
-  local function processLine(line)
-    local leading_spaces, hashes, spacing_after_hashes, heading_text = line:match("^(%s*)(#+)(%s*)(.*)$")
-    if not hashes then
-      return line
-    end
-
-    local adjusted_heading_text = heading_text or ""
-    if spacing_after_hashes then
-      adjusted_heading_text = spacing_after_hashes .. adjusted_heading_text
-    end
-    adjusted_heading_text = adjusted_heading_text:gsub("^%s*", "")
-    adjusted_heading_text = adjusted_heading_text:gsub("%s*$", "")
-
-    local new_level = #hashes + heading_shift
-    if new_level > max_heading_level then
-      if adjusted_heading_text ~= "" then
-        return leading_spaces .. "**" .. adjusted_heading_text .. "**"
-      end
-      return leading_spaces .. "**" .. "**"
-    end
-
-    local new_hashes = string.rep("#", new_level)
-    if adjusted_heading_text == "" then
-      return leading_spaces .. new_hashes
-    end
-    return leading_spaces .. new_hashes .. " " .. adjusted_heading_text
-  end
-
-  while start_index <= content_length do
-    local newline_index = content:find("\n", start_index, true)
-    if newline_index then
-      local line = content:sub(start_index, newline_index - 1)
-      table.insert(normalized_lines, processLine(line))
-      start_index = newline_index + 1
-    else
-      local line = content:sub(start_index)
-      if line ~= "" or not has_trailing_newline then
-        table.insert(normalized_lines, processLine(line))
-      end
-      break
-    end
-  end
-
-  local normalized_content = table.concat(normalized_lines, "\n")
-  if has_trailing_newline then
-    normalized_content = normalized_content .. "\n"
-  end
-  return normalized_content
-end
-
 return {
-    getGeneralNotebookFilePath = getGeneralNotebookFilePath,
     extractBookTextForAnalysis = extractBookTextForAnalysis,
     extractHighlightsNotesAndNotebook = extractHighlightsNotesAndNotebook,
     getPageInfo = getPageInfo,
-    saveToNotebookFile = saveToNotebookFile,
-    normalizeMarkdownHeadings = normalizeMarkdownHeadings
+    saveToNotebookFile = saveToNotebookFile
 }


### PR DESCRIPTION
When extracting book text, string.sub might cut a multi-byte UTF-8 character (like Chinese) in half. This leads to an "invalid unicode" error from APIs like DeepSeek. Added a regex to clear leading truncated bytes.