### PR TITLE
fix: remove query animation that caused flashing

### DIFF
--- a/assistant_querier.lua
+++ b/assistant_querier.lua
@@ -174,11 +174,6 @@ function Querier:query(message_history, title)
     local use_stream_mode = self.settings:readSetting("use_stream_mode", true)
     koutil.tableSetValue(self.provider_settings, use_stream_mode, "additional_parameters", "stream")
 
-    -- Set up waiting animation for non-streaming mode
-    local animation = createWaitingAnimation()
-    local animation_task = nil
-    local response_received = false
-
     local infomsg = InfoMessage:new{
       icon = "book.opened",
       text = string.format("%s\n️☁️ %s\n⚡ %s", title or _("Querying AI ..."), self.provider_name,
@@ -187,27 +182,9 @@ function Querier:query(message_history, title)
 
     UIManager:show(infomsg)
 
-    -- Start animation for non-streaming mode
-    local initial_text = infomsg.text
-    local function updateInfoMessage()
-        if not response_received then
-            infomsg.text = initial_text .. "\n" .. animation:getNextFrame()
-            UIManager:setDirty(infomsg)
-            animation_task = UIManager:scheduleIn(0.4, updateInfoMessage)
-        end
-    end
-    animation_task = UIManager:scheduleIn(0.4, updateInfoMessage)
-
     self.handler:setTrapWidget(infomsg)
     local res, err = self.handler:query(trimMessageHistory(message_history), self.provider_settings)
     self.handler:resetTrapWidget()
-
-    -- Stop animation
-    response_received = true
-    if animation_task then
-        UIManager:unschedule(animation_task)
-        animation_task = nil
-    end
 
     UIManager:close(infomsg)
 


### PR DESCRIPTION
Previously I was using the upstream/original project, where running a query showed a modal with the model provider and model. This modal was static, as a lot of Koreader modals are, even if they're doing something in the background (eg the "turning on wifi" modal)

After switching to this fork (thank you for maintaining it), I noticed the same modal flashing the screen ~14 times (per query, over a few seconds), with no animation or rendering that justified the repaints.

Per discussion with Claude, the underlying bug is that the modal intends to show a waiting animation but never actually renders one, so all that's left is the flashing.

Rather than fix the animation, I opted to remove it altogether, which also removes the flashing. Details below.

## What

Removes the waiting-dot animation from the non-streaming branch of
`Querier:query` (`assistant_querier.lua`).

## Why

The animation never actually rendered, and could cause a brief flash on
the "Querying AI …" InfoMessage. Two reasons:

1. **The text never updated visually.** The animation worked by mutating
   `infomsg.text` and calling `UIManager:setDirty(infomsg)` on a 0.4s
   timer. But `InfoMessage` builds its text widget once in `init()`;
   reassigning `.text` afterward and marking it dirty just repaints the
   *original* content. (The streaming dialog animates correctly because
   it calls `_input_widget:setText(frame, true)`, an actual update method
   on the widget — not a field reassignment.)

2. **The request already blocks behind a subprocess.** In non-streaming
   mode the HTTP call goes through `BaseHandler:makeRequest`, which —
   when a trap widget is set — runs in `Trapper:dismissableRunInSubprocess`.
   The InfoMessage is effectively static for the duration regardless of
   the scheduled task.

So the code added a per-frame `scheduleIn`/`unschedule` cycle and extra
state (`response_received`, `animation_task`) for no visible effect.
Removing it simplifies the path and avoids the flash.

`createWaitingAnimation()` is intentionally kept — the streaming path
still uses it.
