### PR TITLE
fix: pipe tables render correctly when hoedown is unavailable

### DIFF
--- a/assistant_mdparser.lua
+++ b/assistant_mdparser.lua
@@ -52,4 +52,55 @@ if not Parser then
     logger.info("Using markdown.lua (pure Lua) for markdown parsing")
 end
 
+-- Post-processor: convert pipe-table <p> blocks that luamd passes through
+-- verbatim into proper <table> HTML that CRE can render.
+-- Safe for hoedown too: hoedown already emits <table> tags, so no <p>|...|</p>
+-- blocks will match and this becomes a no-op.
+local function render_tables(html)
+    return (html:gsub("<p>([%s%S]-)</p>", function(block)
+        if not block:match("^%s*|") then
+            return nil
+        end
+
+        local rows = {}
+        for line in block:gmatch("[^\r\n]+") do
+            local trimmed = line:match("^%s*(.-)%s*$")
+            if trimmed ~= "" then
+                rows[#rows + 1] = trimmed
+            end
+        end
+
+        if #rows < 3 then return nil end
+
+        if not rows[2]:match("^|?[%s%-:|]+|$") then return nil end
+
+        local out = { "<table>" }
+
+        for i, row in ipairs(rows) do
+            if i == 2 then
+                -- skip separator row
+            else
+                local tag = (i == 1) and "th" or "td"
+                local inner = row:match("^|?(.+)|?$") or ""
+                out[#out + 1] = "<tr>"
+                for cell in (inner .. "|"):gmatch("(.-)|") do
+                    local c = cell:match("^%s*(.-)%s*$")
+                    if c ~= "" then
+                        out[#out + 1] = string.format("<%s>%s</%s>", tag, c, tag)
+                    end
+                end
+                out[#out + 1] = "</tr>"
+            end
+        end
+
+        out[#out + 1] = "</table>"
+        return table.concat(out)
+    end))
+end
+
+local raw_parser = Parser
+Parser = function(text)
+    return render_tables(raw_parser(text))
+end
+
 return Parser


### PR DESCRIPTION
Adds a `render_tables()` post-processor to `assistant_mdparser.lua`. Tables in AI responses now display as proper HTML tables instead of raw pipe characters.

In practice hoedown is not available on most KOReader installs — no `libhoedown.so.3` in the plugin lib dir, no system install. So basically everyone runs on the luamd fallback, which has no table support. luamd wraps the whole pipe block in a single `<p>` with literal newlines and passes it through. CRE can render `<table>` HTML fine, luamd just never emits it.

The post-processor scans for `<p>` blocks starting with `|` and rewrites them as `<table><tr><th/td>` HTML. One thing to note: Lua's `.` does not cross newlines in patterns, so the gsub uses `[%s%S]` — a naive `<p>(.-)</p>` would never match a multi-line block.

Is a no-op when hoedown is present. Tested on Kindle Paperwhite KOReader v2026.03, assistant.koplugin v1.11.