### PR TITLE
feat: add SearXNG as a self-hosted web search provider

### DIFF
--- a/api_handlers/anthropic.lua
+++ b/api_handlers/anthropic.lua
@@ -86,7 +86,7 @@ function AnthropicHandler:query(message_history, anthropic_settings, query_optio
     -- -----------------------------------------------------------------------
     if query_option.use_stream_mode then
         local stream_tools = nil
-        if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             stream_tools = { self:buildExternalSearchToolDef("anthropic") }
         end
         local body = buildRequestBody(message_history, anthropic_settings, stream_tools, true)
@@ -101,7 +101,7 @@ function AnthropicHandler:query(message_history, anthropic_settings, query_optio
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local requestBody
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         local search_tool = { self:buildExternalSearchToolDef("anthropic") }
         requestBody = buildRequestBody(message_history, anthropic_settings, search_tool, false)
     else

--- a/api_handlers/azure_openai.lua
+++ b/api_handlers/azure_openai.lua
@@ -47,7 +47,7 @@ function AzureOpenAIHandler:query(message_history, azure_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local tools
-    if not query_option.use_stream_mode and (ws_mode == "serpapi" or ws_mode == "tavilyapi") then
+    if not query_option.use_stream_mode and (ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng") then
         tools = { self:buildExternalSearchToolDef("openai") }
     end
 

--- a/api_handlers/deepseek.lua
+++ b/api_handlers/deepseek.lua
@@ -47,7 +47,7 @@ function DeepSeekHandler:query(message_history, deepseek_settings, query_option)
         -- Inject tool definition so the LLM can issue a tool_call in the stream.
         -- The Querier's stream tool-call loop will detect it and execute the search.
         local stream_tools = nil
-        if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             stream_tools = { self:buildExternalSearchToolDef("openai") }
         end
         local requestBodyTable = buildRequestBody(message_history, stream_tools)
@@ -63,7 +63,7 @@ function DeepSeekHandler:query(message_history, deepseek_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local tools
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         tools = { self:buildExternalSearchToolDef("openai") }
     end
     local requestBodyTable = buildRequestBody(message_history, tools)

--- a/api_handlers/gemini.lua
+++ b/api_handlers/gemini.lua
@@ -116,7 +116,7 @@ function GeminiHandler:query(message_history, gemini_settings, query_option)
         local tools = nil
         if ws_mode == "builtin" then
             tools = { google_search = {} }
-        elseif ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        elseif ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             tools = self:buildExternalSearchToolDef("gemini")
         end
         local requestBody = buildRequestBody(message_history, gemini_settings, tools, true)
@@ -130,7 +130,7 @@ function GeminiHandler:query(message_history, gemini_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local final_tools = nil
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         final_tools = self:buildExternalSearchToolDef("gemini")
     elseif ws_mode == "builtin" then
         -- Built-in Google Search grounding for non-stream

--- a/api_handlers/gigachat.lua
+++ b/api_handlers/gigachat.lua
@@ -46,7 +46,7 @@ function GigaChatHandler:query(message_history, gigachat_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local tools
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         tools = { self:buildExternalSearchToolDef("openai") }
     end
 

--- a/api_handlers/groq.lua
+++ b/api_handlers/groq.lua
@@ -51,7 +51,7 @@ function groqHandler:query(message_history, groq_settings, query_option)
         -- Built-in web search for groq/compound* models
         if ws_mode == "builtin" and groq_settings.model:find("^groq/compound") then
             body.compound_custom = { tools = { enabled_tools = { "web_search", "visit_website" } } }
-        elseif ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        elseif ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             body.tools = { self:buildExternalSearchToolDef("openai") }
         end
         local requestBody = json.encode(body)
@@ -66,7 +66,7 @@ function groqHandler:query(message_history, groq_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local tools
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         tools = { self:buildExternalSearchToolDef("openai") }
     end
     local body = buildRequestBody(message_history, groq_settings, tools, false)

--- a/api_handlers/mistral.lua
+++ b/api_handlers/mistral.lua
@@ -41,7 +41,7 @@ function MistralHandler:query(message_history, mistral_settings, query_option)
         -- Inject tool definition so the LLM can issue a tool_call in the stream.
         -- The Querier's stream tool-call loop will detect it and execute the search.
         local stream_tools = nil
-        if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             stream_tools = { self:buildExternalSearchToolDef("openai") }
         end
         local requestBodyTable = buildRequestBody(message_history, stream_tools)
@@ -63,7 +63,7 @@ function MistralHandler:query(message_history, mistral_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local tools
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         tools = { self:buildExternalSearchToolDef("openai") }
     end
     local requestBodyTable = buildRequestBody(message_history, tools)

--- a/api_handlers/ollama.lua
+++ b/api_handlers/ollama.lua
@@ -41,7 +41,7 @@ function OllamaHandler:query(message_history, ollama_settings, query_option)
         -- The Querier's stream tool-call loop will detect it and execute the search.
         -- Note: tool-call support depends on the specific Ollama model in use.
         local stream_tools = nil
-        if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             stream_tools = { self:buildExternalSearchToolDef("openai") }
         end
         local requestBodyTable = buildRequestBody(message_history, stream_tools)
@@ -57,7 +57,7 @@ function OllamaHandler:query(message_history, ollama_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local tools
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         tools = { self:buildExternalSearchToolDef("openai") }
     end
     local requestBodyTable = buildRequestBody(message_history, tools)

--- a/api_handlers/openai.lua
+++ b/api_handlers/openai.lua
@@ -39,7 +39,7 @@ function OpenAIHandler:query(message_history, openai_settings, query_option)
     -- -----------------------------------------------------------------------
     if query_option.use_stream_mode then
         local tools
-        if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             tools = { self:buildExternalSearchToolDef("openai") }
         end
         local body = buildRequestBody(message_history, openai_settings, tools, true)
@@ -55,7 +55,7 @@ function OpenAIHandler:query(message_history, openai_settings, query_option)
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local requestBody
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         local search_tool = { self:buildExternalSearchToolDef("openai") }
         requestBody = buildRequestBody(message_history, openai_settings, search_tool, false)
     else

--- a/api_handlers/openrouter.lua
+++ b/api_handlers/openrouter.lua
@@ -80,7 +80,7 @@ function OpenRouterProvider:query(message_history, openrouter_settings, query_op
         if ws_mode == "builtin" then
             -- OpenRouter native web-search server tool
             stream_tools = { buildWebSearchTool(openrouter_settings.additional_parameters) }
-        elseif ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+        elseif ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
             -- Inject standard tool definition so the LLM can issue a tool_call in the stream.
             -- The Querier's stream tool-call loop will detect it and execute the search.
             stream_tools = { self:buildExternalSearchToolDef("openai") }
@@ -103,7 +103,7 @@ function OpenRouterProvider:query(message_history, openrouter_settings, query_op
     -- In non-stream mode, inject tool definitions if web_search is enabled.
     -- Let the Querier handle the tool-call loop and search execution.
     local tools
-    if ws_mode == "serpapi" or ws_mode == "tavilyapi" then
+    if ws_mode == "serpapi" or ws_mode == "tavilyapi" or ws_mode == "searxng" then
         tools = { self:buildExternalSearchToolDef("openai") }
     end
 

--- a/assistant_featuredialog.lua
+++ b/assistant_featuredialog.lua
@@ -59,7 +59,7 @@ local function showFeatureDialog(assistant, feature_type, title, author, progres
         -- Feature type configurations for easy extension
         local feature_configurations = {
             recap = {
-                title = _("Recap"),
+                title = _("🌐Recap"),
                 loading_message = _("Loading Recap..."),
                 config_key = "recap_config",
                 prompts_key = "recap"
@@ -71,7 +71,7 @@ local function showFeatureDialog(assistant, feature_type, title, author, progres
                 prompts_key = "xray"
             },
             book_info = {
-                title = _("Book Information"),
+                title = _("🌐Book Information"),
                 loading_message = _("Loading Book Information..."),
                 config_key = "book_info_config",
                 prompts_key = "book_info"

--- a/assistant_prompts.lua
+++ b/assistant_prompts.lua
@@ -24,7 +24,7 @@ local markdown_format_prompt = [[
 -- prompts attributes can be overridden in the configuration file.
 local custom_prompts = {
     term_xray = {
-        text = _("Term X-Ray"),
+        text = _("🌐Term X-Ray"),
         use_websearch = true,
         order = -20, -- negative number to not show on additional questions dialog
         desc = _(
@@ -268,7 +268,7 @@ Provide a concise, simple, and crystal-clear ELI5 explanation of the following, 
 {highlight}.]],
     },
     explain = {
-        text = _("Explain"),
+        text = _("🌐Explain"),
         use_websearch = true,
         order = 80,
         desc = _("This prompt explains the highlighted text in detail, ensuring clarity and understanding."),
@@ -282,7 +282,7 @@ Ensure your {language} explanation is precise, captures all nuances of the origi
 {highlight}]],
     },
     historical_context = {
-        text = _("Historical Context"),
+        text = _("🌐Historical Context"),
         use_websearch = true,
         order = 90,
         desc = _(
@@ -298,7 +298,7 @@ Please provide a detailed and insightful explanation of the historical context o
 {highlight}]],
     },
     wikipedia = {
-        text = _("Wikipedia"),
+        text = _("🌐Wikipedia"),
         use_websearch = true,
         order = 100,
         desc = _(

--- a/assistant_querier.lua
+++ b/assistant_querier.lua
@@ -99,6 +99,7 @@ function Querier:load_model(provider_name)
     end
     ToolExecutor.setSearchAPIConfig("serpapi", koutil.tableGetValue(CONFIGURATION, "provider_settings", "serpapi"))
     ToolExecutor.setSearchAPIConfig("tavilyapi", koutil.tableGetValue(CONFIGURATION, "provider_settings", "tavilyapi"))
+    ToolExecutor.setSearchAPIConfig("searxng", koutil.tableGetValue(CONFIGURATION, "provider_settings", "searxng"))
 
     local handler_name
     local underscore_pos = provider_name:find("_")

--- a/assistant_settings.lua
+++ b/assistant_settings.lua
@@ -406,6 +406,8 @@ SettingsDialog.genWebSearchSubMenuItem = function(assistant, key)
                 return koutil.tableGetValue(assistant.CONFIGURATION, "provider_settings", "serpapi", "api_key") ~= nil
             elseif key == "tavilyapi" then
                 return koutil.tableGetValue(assistant.CONFIGURATION, "provider_settings", "tavilyapi", "api_key") ~= nil
+            elseif key == "searxng" then
+                return koutil.tableGetValue(assistant.CONFIGURATION, "provider_settings", "searxng", "base_url") ~= nil
             end
             return false --
         end

--- a/assistant_tool_executor.lua
+++ b/assistant_tool_executor.lua
@@ -19,6 +19,7 @@ local json_default = assistant_utils.json_default
 local SEARCH_API_CONF = {
     serpapi   = { base_url = nil, api_key = ""},
     tavilyapi = { base_url = nil, api_key = ""},
+    searxng   = { base_url = nil, api_key = ""},
 }
 -- ---------------------------------------------------------------------------
 -- External-search two-stage flow (used by handlers that don't natively
@@ -118,6 +119,45 @@ local function tavilyAPISearchRequest(handler, keywords)
         segments:put("---")
         segments:putf("### Source %d: %s", i, json_default(item.title, "Untitled"))
         -- segments:put( string.format("* URL: %s", json_default(item.url, "N/A")))
+        segments:put("* Summary: ")
+        segments:put(json_default(item.content, ""))
+        segments:put("\n")
+    end
+    segments:put("\n")
+    return true, segments:get()
+end
+
+local function searxngAPISearchRequest(handler, keywords)
+    local searxngconfig = SEARCH_API_CONF.searxng
+    local base_url = searxngconfig.base_url or "http://localhost:8888/search"
+    local key      = searxngconfig.api_key
+    local q        = koutil.urlEncode(keywords)
+    local url      = T("%1?q=%2&format=json", base_url, q)
+
+    local timeout = 45
+    local maxtime = 120
+
+    local completed, success, code, content =
+        Trapper:dismissableRunInSubprocess(function()
+            return assistant_utils.httpRequest(url, timeout, maxtime, nil, nil, nil)
+        end, handler.trap_widget)
+
+    if not completed then return false, handler.CODE_CANCELLED end
+    if not success or code ~= 200 then return false, content end
+
+    local ok, parsed = pcall(json.decode, content)
+    if not ok or not parsed or not parsed.results then
+        return false, "fail to parse searxng return"
+    end
+
+    local segments = strbuf.new()
+    segments:put("## Web Search Results:\n")
+    for i, item in ipairs(parsed.results) do
+        segments:put("---")
+        segments:putf("### Source %d: %s", i, json_default(item.title, "Untitled"))
+        segments:put("* URL: ")
+        segments:put(json_default(item.url, "N/A"))
+        segments:put("\n")
         segments:put("* Summary: ")
         segments:put(json_default(item.content, ""))
         segments:put("\n")
@@ -241,6 +281,8 @@ function ToolExecutor.executeWebSearch(keywords, ws_mode, handler, tool_round)
         search_ok, search_result = serpAPISearchRequest(handler, keywords)
     elseif ws_mode == "tavilyapi" then
         search_ok, search_result = tavilyAPISearchRequest(handler, keywords)
+    elseif ws_mode == "searxng" then
+        search_ok, search_result = searxngAPISearchRequest(handler, keywords)
     else
         UIManager:close(handler:resetTrapWidget())
         return false, "Unknown web-search mode: " .. tostring(ws_mode)
@@ -573,7 +615,8 @@ function ToolExecutor.SettingkeyToText(key)
         ["none"] = _("None"),
         ["builtin"] = _("Model Built-In"),
         ["serpapi"] = "Serp API",
-        ["tavilyapi"] = "Tavily API"
+        ["tavilyapi"] = "Tavily API",
+        ["searxng"] = "SearXNG"
     }
     return ToolText[key]
 end

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -237,6 +237,9 @@ local CONFIGURATION = {
         tavilyapi = {
             api_key = "your-tavily-api-key"
         },
+        searxng = {
+            base_url = "http://localhost:8888/search",
+        },
     },
 
     -- Optional features

--- a/main.lua
+++ b/main.lua
@@ -233,6 +233,7 @@ function Assistant:addToMainMenu(menu_items)
                       SettingsDialog.genWebSearchSubMenuItem(self, "builtin"),
                       SettingsDialog.genWebSearchSubMenuItem(self, "serpapi"),
                       SettingsDialog.genWebSearchSubMenuItem(self, "tavilyapi"),
+                      SettingsDialog.genWebSearchSubMenuItem(self, "searxng"),
                   },
               },
               {
@@ -248,7 +249,7 @@ function Assistant:addToMainMenu(menu_items)
                 text = _("Book-Level Built-in Prompts"),
                 sub_item_table = {
                   {
-                    text = _("Book Summary & Recs"),
+                    text = _("🌐Book Summary & Recs"),
                     callback = function ()
                       self:onAskAIBookInfo()
                     end,
@@ -259,7 +260,7 @@ function Assistant:addToMainMenu(menu_items)
                     end
                   },
                   {
-                    text = _("AI X-Ray"),
+                    text = _("🌐AI X-Ray"),
                     callback = function ()
                       self:onAskAIXRay()
                     end,
@@ -270,7 +271,7 @@ function Assistant:addToMainMenu(menu_items)
                     end
                   },
                   {
-                    text = _("AI Recaps"),
+                    text = _("🌐AI Recaps"),
                     callback = function ()
                       self:onAskAIRecap()
                     end,
@@ -292,7 +293,7 @@ function Assistant:addToMainMenu(menu_items)
                     end,
                   },
                   {
-                    text = _("Summary Using Highlights & Notes"),
+                    text = _("🌐Summary Using Highlights & Notes"),
                     callback = function ()
                       self:onAskSummaryUsingAnnotations()
                     end,


### PR DESCRIPTION
Adds **SearXNG** as a new web search provider alongside the existing SerpAPI and TavilyAPI options. SearXNG is a privacy-focused, self-hosted meta-search engine that requires no API key.

**Changes**

- **`assistant_tool_executor.lua`**: Added `searxng` entry to `SEARCH_API_CONF`; implemented `searxngAPISearchRequest()` using `GET ?q={keywords}&format=json` parsing `results[].{title, url, content}`; wired dispatch in `executeWebSearch()` and label in `SettingkeyToText()`
- **`configuration.sample.lua`**: Added `searxng = { base_url = "http://localhost:8888/search" }` config block (no API key needed)
- **`main.lua`**: Added `searxng` sub-item in the Smart Web Search settings menu
- **`assistant_settings.lua`**: Added `enabled_func` validation that checks for a non-nil `base_url`
- **`assistant_querier.lua`**: Added `setSearchAPIConfig("searxng", ...)` call on provider load
- **All 10 `api_handlers/*.lua`**: Extended `ws_mode` checks to inject external search tools when `ws_mode == "searxng"` (alongside existing `"serpapi"` / `"tavilyapi"`)

**Testing**
Tested end-to-end against a live SearXNG instance (2026.6.26). The plugin correctly:
- Sends JSON-format queries to the configured `base_url`
- Parses and formats search results into the tool-call response
- Falls back gracefully on error (engine failures → `"fail to parse searxng return"`)

**Disclaimer**
This implementation was written with assistance from **Deepseek V4 Flash** (via opencode CLI agent). Code was reviewed and verified manually before commit.

P.S. This is my first GitHub contribution ever — if there's any feedback, please share!