### PR TITLE
Introducing Book Companion

### DIFF
--- a/.claude/skills/book-companion/SKILL.md
+++ b/.claude/skills/book-companion/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: book-companion
+description: Use when the user wants to generate a Book Companion reference (a `.companion.md` sidecar) for a book — given a Calibre title, an ePub, or a `.md`/`.txt` file. Produces a spoiler-safe, comprehension-first companion and writes it to the repo `companions/` folder and beside the book.
+---
+
+# Book Companion Generator
+
+Generate a `<book-stem>.companion.md` reference for the assistant.koplugin Book
+Companion feature. **Comprehension over plot**: the reader's barrier is lost cultural,
+historical, and linguistic knowledge — prioritize terms, references, allusions, and
+untranslated phrases; keep the plot pass lean (it is scaffolding and the spoiler anchor).
+
+Deterministic Python scripts (under `scripts/`) own ingestion, structure, verification,
+and writing. **You** own the comprehension writing. Scripts feed you (manifest +
+candidates) and check you (verification report).
+
+## Inputs
+
+One of: a **book title** (resolve via Calibre), an **ePub path**, or a **`.md`/`.txt` path**.
+
+## Procedure
+
+### 1. Resolve the source
+- **Title:** run `python3 scripts/resolve_book.py "<title>"`.
+  - `status: resolved` → use `source`.
+  - `status: ambiguous` → show `candidates` (title — authors — id) and ask which.
+  - `status: not_found` → ask the user to refine the title or give a path.
+- **Path:** use it directly.
+
+### 2. Ingest
+Run `python3 scripts/ingest.py "<source>" --out <workdir>` (use a scratch dir).
+Read `<workdir>/manifest.json`. Note `size_class`, `chapters`, `structural_confidence`.
+If `structural_confidence` is `low`, warn the user the chapter pass is best-effort.
+
+### 3. Harvest candidates
+Run `python3 scripts/harvest_candidates.py "<workdir>/normalized.md" > <workdir>/candidates.json`.
+This is your **coverage checklist** for foreign phrases, epigraphs, and recurring names.
+
+### 4. Chapter pass (adaptive — driven by `size_class`)
+- **small:** read `normalized.md` yourself; take ≈1–2 lean bullets per chapter and note
+  glossary/allusion/foreign-phrase/character material as you go.
+- **large:** for each entry in `manifest.parts`, dispatch a subagent over that
+  `char_start:char_end` slice of `normalized.md`. Each subagent returns: (a) lean
+  chapter bullets for its range, and (b) a harvest of names, glossary-worthy terms,
+  foreign phrases, and allusions. Then merge: dedupe characters by name-as-spelled;
+  union the glossary/allusion/phrase sets.
+
+### 5. Synthesize the companion
+Following `references/section-guide.md` and `references/spoiler-rules.md`, write the
+companion. Lead with the comprehension sections' depth; keep the plot pass lean.
+Use the Middlemarch exemplar (`references/exemplar.md`) as the quality bar.
+**Spoiler discipline is mandatory** — spoiler-free identity lines; arcs only on
+`↳ _Arc (spoiler):_` lines; chapter-anchored plot. Save the draft to `<workdir>/draft.md`.
+
+### 6. Write to both destinations
+Determine the book folder (for a Calibre/ePub source, the directory containing the
+source file; for a path input, that file's directory). Then:
+```
+python3 scripts/write_companion.py --content <workdir>/draft.md --source "<source>" \
+  --repo-companions companions --book-folder "<book-folder>"
+```
+
+### 7. Verify (mechanical gate)
+```
+python3 scripts/verify_companion.py --companion companions/<stem>.companion.md \
+  --manifest <workdir>/manifest.json --source <workdir>/normalized.md \
+  --candidates <workdir>/candidates.json --stem "<stem>" \
+  --paths "<path1>,<path2>"
+```
+`<path1>,<path2>` are the two file paths that `write_companion.py` printed in step 6
+(the repo `companions/` copy and the beside-the-book copy), comma-separated.
+**`ok: false` is driven by three hard mechanical gates only:** stray prefix before the
+first `#` heading, missing chapters (a manifest index/title absent from the companion),
+or filename/paths mismatch. Fix any of those and re-run steps 5–7.
+
+`names_missing_from_source` and `phrases_uncovered` are **advisory** lists in the
+report — they do NOT affect `ok`. Review them during the step 8 judgment self-check:
+a flagged name may be a hallucination or misspelling worth correcting, or merely a
+multi-name group label (e.g. `**Dr. A & Dr. B**`) that harvest never sees verbatim;
+a flagged phrase may be harvest noise rather than a real gap.
+
+### 8. Judgment self-check (you, not a script)
+Confirm: foreign phrases are translated and glossed; allusions are **explained**, not
+named; no spoilers in §1 or identity lines; nothing fabricated beyond what the source
+or well-established knowledge supports. Also eyeball `names_missing_from_source` and
+`phrases_uncovered` from the step 7 report — fix genuine hallucinations or gaps, ignore
+false positives (group labels, harvest noise).
+
+## Notes
+- Scripts are stdlib-only; no setup step.
+- Deploying the companion to the device is a separate manual step.
+- This is a public repo — never write secrets.

--- a/.claude/skills/book-companion/references/exemplar.md
+++ b/.claude/skills/book-companion/references/exemplar.md
@@ -1,6 +1,6 @@
 # Quality Bar: the Middlemarch exemplar
 
-`Middlemarch_Reference_Companion.md` at the repo root is the field-proven reference.
+A field-proven reference companion — such as a generated `Middlemarch.companion.md`, if you have one on hand — is the example here.
 Treat it as the **quality and convention** bar, not a rigid template:
 
 - Match its density, tone, and the spoiler-free/`↳ _Arc` convention.
@@ -8,5 +8,5 @@ Treat it as the **quality and convention** bar, not a rigid template:
 - Its eight sections are a menu, not a mandate — include what a given book needs
   (see `section-guide.md`).
 
-When generating a companion for Middlemarch itself, diff your output against this file:
+When generating a companion for Middlemarch itself, diff your output against such a reference if you have one:
 structure, density, spoiler conventions, and chapter coverage should line up.

--- a/.claude/skills/book-companion/references/exemplar.md
+++ b/.claude/skills/book-companion/references/exemplar.md
@@ -1,0 +1,12 @@
+# Quality Bar: the Middlemarch exemplar
+
+`Middlemarch_Reference_Companion.md` at the repo root is the field-proven reference.
+Treat it as the **quality and convention** bar, not a rigid template:
+
+- Match its density, tone, and the spoiler-free/`↳ _Arc` convention.
+- Do **not** copy its Victorian-specific sections wholesale; generalize the *shape*.
+- Its eight sections are a menu, not a mandate — include what a given book needs
+  (see `section-guide.md`).
+
+When generating a companion for Middlemarch itself, diff your output against this file:
+structure, density, spoiler conventions, and chapter coverage should line up.

--- a/.claude/skills/book-companion/references/section-guide.md
+++ b/.claude/skills/book-companion/references/section-guide.md
@@ -1,0 +1,61 @@
+# Companion Section Guide
+
+The companion is **comprehension-first**: the reader's barrier is lost cultural,
+historical, and linguistic knowledge. Prioritize terms, references, allusions, and
+untranslated phrases. The plot pass is lean scaffolding (and the spoiler anchor).
+
+## Always include (core)
+
+### 1. Quick Orientation
+2–4 paragraphs: setting, period, social world, and the through-lines. Orient a cold
+reader. **No later-book outcomes** (spoiler-free).
+
+### 2. Character Dictionary
+Each entry: a **spoiler-free identity line** (`**Name** *(first appears: …)* — role`),
+followed *only when needed* by an indented arc line. See `spoiler-rules.md`.
+
+### 3. Chapter-by-Chapter Plot
+≈1–2 tight bullets per chapter, each under a heading that names the chapter
+(`### Chapter <N>` or the book's own `### Book II, Chapter 14`). This is scaffolding —
+keep it lean. Chapter-anchoring is what lets the runtime spoiler guard work.
+
+## Include whenever the book has such content — be thorough here
+
+### 4. Historical / Political / Social Glossary
+Institutions, customs, money, law, status markers a modern reader won't know.
+Define them; tie each to how it matters in the book.
+
+### 5. Allusions & References
+Biblical, classical/mythological, literary, scientific. **Explain** each — don't just
+name it. Group by kind when there are many.
+
+### 6. Foreign-Language Phrases
+Every untranslated phrase, with a translation and an in-context gloss. The harvest from
+`harvest_candidates.py` is your checklist; cover all of it that is genuinely foreign.
+
+### 7. Motifs & Symbols
+Recurring images and their interpretive weight.
+
+## Adaptive
+
+### 8. Reading the [Author]'s Narrator
+Only when the narrative voice/technique is itself a comprehension barrier (e.g. free
+indirect discourse, an unreliable narrator).
+
+### Book-specific section
+Add one when the work warrants it (e.g. a timeline for a time-jumping novel).
+
+## Omission
+Sections that genuinely don't apply are **omitted, not padded**. A modern
+plain-language thriller likely has no §6 and a thin §4.
+
+## Formatting
+
+Top-level companion sections use `##` headings. Within the **Character Dictionary**,
+reserve `**bold**` for character names (or direct name-group labels) so the verifier's
+name-presence check stays meaningful — avoid bolding non-name labels or descriptors.
+
+## Density
+Mirror the Middlemarch exemplar's density for known-good calibration. For very long
+books, tighten the chapter pass toward 1 bullet/chapter so the whole companion stays
+usable at injection time.

--- a/.claude/skills/book-companion/references/spoiler-rules.md
+++ b/.claude/skills/book-companion/references/spoiler-rules.md
@@ -1,0 +1,38 @@
+# Spoiler Rules (load-bearing)
+
+The runtime spoiler guard (`assistant_prompts.lua` companion prompt) trusts the
+companion to be authored so that material before a reader's position never leaks
+later events. Author every companion to make that possible.
+
+## Character Dictionary format
+
+Spoiler-free identity first; arc (if any) **only** on its own line that opens with
+the exact marker `↳ _Arc (spoiler):_`. The `↳` glyph provides the visual offset — do
+**not** add literal leading spaces (4+ leading spaces make Markdown render the line as a
+code block and break the companion). Keep the `↳ _Arc` line flush-left, as in the
+Middlemarch exemplar.
+
+```
+**Dorothea Brooke** *(first appears: Book I, Ch 1)* — Ardent, intelligent young
+gentlewoman and heiress; yearns for a life of great usefulness.
+↳ _Arc (spoiler):_ Marries the older scholar Casaubon; widowed; eventually marries
+Will Ladislaw.
+```
+
+Rules:
+- The identity line must reveal **no** fate, death, marriage, betrayal, or twist.
+- Everything that happens *to* a character over the book goes on the `↳ _Arc` line.
+- Keep the marker verbatim and the line flush-left (no leading spaces) so it is visually
+  and programmatically separable.
+
+## Quick Orientation
+Describes the world and premise, **not** the ending. No outcomes.
+
+## Chapter-by-Chapter Plot
+Each bullet belongs to the chapter where the event happens, so a reader at chapter N
+only ever sees up to chapter N. Never foreshadow a later chapter's reveal in an
+earlier chapter's bullets.
+
+## Self-check before finishing
+Re-read §1 and every identity line. If any sentence states something a reader would
+consider a spoiler, move it to an `↳ _Arc` line or a later chapter bullet.

--- a/.claude/skills/book-companion/scripts/common.py
+++ b/.claude/skills/book-companion/scripts/common.py
@@ -1,0 +1,17 @@
+"""Shared helpers for the book-companion scripts. Standard library only."""
+import math
+import os
+
+SIZE_THRESHOLD_TOKENS = 60000
+
+def companion_stem(source_path):
+    """Basename of source_path with its final extension removed."""
+    base = os.path.basename(source_path)
+    root, ext = os.path.splitext(base)
+    return root if ext else base
+
+def companion_filename(source_path):
+    return companion_stem(source_path) + ".companion.md"
+
+def estimate_tokens(text):
+    return max(1, math.ceil(len(text) / 4))

--- a/.claude/skills/book-companion/scripts/harvest_candidates.py
+++ b/.claude/skills/book-companion/scripts/harvest_candidates.py
@@ -1,0 +1,49 @@
+"""Surface comprehension candidates for LLM curation. Stdlib only.
+
+Heuristics propose; the LLM disposes. False positives are expected and fine —
+the LLM curates and explains; the goal is to never silently MISS a foreign phrase.
+"""
+import argparse
+import json
+import re
+import sys
+
+_EMPHASIS = re.compile(r"(?<!\*)\*(?!\*)([^*\n]+?)\*(?!\*)|(?<!_)_(?!_)([^_\n]+?)_(?!_)")
+_ACCENTED_RUN = re.compile(r"[A-Za-z]*[À-ÖØ-öø-ÿ][\w''\-]*(?:\s+[\w''\-]*[À-ÖØ-öø-ÿ][\w''\-]*)*")
+_BLOCKQUOTE = re.compile(r"^\s*>\s?(.*\S)\s*$", re.MULTILINE)
+_PROPER = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b")
+
+def _unique(seq):
+    seen, out = set(), []
+    for s in seq:
+        s = s.strip()
+        if s and s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+def harvest(markdown):
+    phrases = []
+    for m in _EMPHASIS.finditer(markdown):
+        phrases.append((m.group(1) or m.group(2) or "").strip())
+    for m in _ACCENTED_RUN.finditer(markdown):
+        phrases.append(m.group(0).strip())
+    epigraphs = _unique(m.group(1) for m in _BLOCKQUOTE.finditer(markdown))
+    counts = {}
+    for m in _PROPER.finditer(markdown):
+        counts[m.group(1)] = counts.get(m.group(1), 0) + 1
+    proper = [name for name, n in sorted(counts.items(), key=lambda kv: -kv[1]) if n >= 2]
+    return {"foreign_phrases": _unique(phrases), "epigraphs": epigraphs, "proper_nouns": proper}
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Harvest comprehension candidates from Markdown.")
+    p.add_argument("markdown")
+    args = p.parse_args(argv)
+    with open(args.markdown, "r", encoding="utf-8", errors="replace") as f:
+        text = f.read()
+    json.dump(harvest(text), sys.stdout, indent=2, ensure_ascii=False)
+    print()
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/book-companion/scripts/ingest.py
+++ b/.claude/skills/book-companion/scripts/ingest.py
@@ -1,0 +1,186 @@
+"""Ingest a book source into normalized Markdown + a manifest. Stdlib only.
+
+This task adds the pure structural functions; Task 5 adds conversion + CLI.
+"""
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+import common
+
+_HEADING = re.compile(r"^(#{1,6})[ \t]+(.*\S)[ \t]*$", re.MULTILINE)
+_CHAPTER_LINE = re.compile(r"^\s*(?:CHAPTER|Chapter)\s+[\w]+.*$", re.MULTILINE)
+
+def _choose_heading_level(markdown: str):
+    """Return the ATX heading level (1–6) with the most occurrences.
+
+    On a tie, returns the smallest (shallowest) level. Returns None if no
+    headings are found.
+
+    Heuristic: assumes the chapter level has more headings than any enclosing
+    structural level (e.g. Middlemarch: 13 Book h2 vs 86 chapter h3). A
+    sub-section-heavy book (chapters with many h3 sub-headings) could mis-split
+    on the sub-section level; acceptable for narrative books at stdlib budget.
+    """
+    counts: dict[int, int] = {}
+    for m in _HEADING.finditer(markdown):
+        level = len(m.group(1))
+        counts[level] = counts.get(level, 0) + 1
+    if not counts:
+        return None
+    max_count = max(counts.values())
+    return min(level for level, count in counts.items() if count == max_count)
+
+
+def _strip_html_tags(text: str) -> str:
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def _chapters_from_matches(text, matches):
+    chapters = []
+    for i, m in enumerate(matches):
+        start = m.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        title = (m.group(2) if m.lastindex and m.lastindex >= 2 else m.group(0)).strip()
+        chapters.append({"index": i + 1, "title": title,
+                         "char_start": start, "char_end": end})
+    if chapters:
+        chapters[0]["char_start"] = 0
+    return chapters
+
+def split_into_chapters(markdown: str):
+    level = _choose_heading_level(markdown)
+    if level is not None:
+        matches = [m for m in _HEADING.finditer(markdown) if len(m.group(1)) == level]
+        return _chapters_from_matches(markdown, matches)
+    chap = list(_CHAPTER_LINE.finditer(markdown))
+    if chap:
+        return _chapters_from_matches(markdown, chap)
+    return [{"index": 1, "title": "Full Text", "char_start": 0, "char_end": len(markdown)}]
+
+def structural_confidence(chapters, detected_from):
+    return "high" if detected_from == "headings" and len(chapters) >= 3 else "low"
+
+def classify_size(token_estimate):
+    return "small" if token_estimate < common.SIZE_THRESHOLD_TOKENS else "large"
+
+def target_parts(token_estimate):
+    return min(12, max(2, math.ceil(token_estimate / 40000)))
+
+def plan_parts(chapters, n_parts):
+    if not chapters:
+        return []
+    total = chapters[-1]["char_end"] - chapters[0]["char_start"]
+    target = max(1, total / n_parts)
+    parts, bucket, acc = [], [], 0
+    for ch in chapters:
+        bucket.append(ch)
+        acc += ch["char_end"] - ch["char_start"]
+        if acc >= target and len(parts) < n_parts - 1:
+            parts.append(bucket)
+            bucket, acc = [], 0
+    if bucket:
+        parts.append(bucket)
+    out = []
+    for i, group in enumerate(parts):
+        out.append({"index": i + 1,
+                    "chapter_range": [group[0]["index"], group[-1]["index"]],
+                    "char_start": group[0]["char_start"],
+                    "char_end": group[-1]["char_end"]})
+    return out
+
+
+def _detect_from(markdown: str) -> str:
+    return "headings" if (_HEADING.search(markdown) or _CHAPTER_LINE.search(markdown)) else "none"
+
+def convert_to_markdown(source_path: str):
+    ext = os.path.splitext(source_path)[1].lower()
+    if ext == ".epub":
+        markdown = _strip_html_tags(_epub_to_markdown(source_path))
+        meta = _epub_metadata(source_path)
+        return markdown, "headings", meta
+    with open(source_path, "r", encoding="utf-8", errors="replace") as f:
+        markdown = f.read()
+    markdown = _strip_html_tags(markdown)
+    return markdown, _detect_from(markdown), {
+        "title": common.companion_stem(source_path), "author": "", "language": ""}
+
+def _epub_to_markdown(source_path):
+    if shutil.which("pandoc"):
+        try:
+            return subprocess.check_output(
+                ["pandoc", "-f", "epub", "-t", "commonmark", source_path],
+                text=True, stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            pass
+    if shutil.which("ebook-convert"):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "out.txt")
+            subprocess.check_call(["ebook-convert", source_path, out],
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            with open(out, "r", encoding="utf-8", errors="replace") as f:
+                return f.read()
+    raise RuntimeError("Neither pandoc nor ebook-convert is available to convert ePub.")
+
+def _epub_metadata(source_path):
+    """Best-effort title/author/language from the OPF inside the ePub zip."""
+    import zipfile
+    meta = {"title": common.companion_stem(source_path), "author": "", "language": ""}
+    try:
+        with zipfile.ZipFile(source_path) as z:
+            opf = next((n for n in z.namelist() if n.lower().endswith(".opf")), None)
+            if not opf:
+                return meta
+            xml = z.read(opf).decode("utf-8", "replace")
+        for key, tag in (("title", "title"), ("author", "creator"), ("language", "language")):
+            m = re.search(r"<dc:%s[^>]*>(.*?)</dc:%s>" % (tag, tag), xml, re.S | re.I)
+            if m:
+                meta[key] = re.sub(r"\s+", " ", m.group(1)).strip()
+    except Exception:
+        pass
+    return meta
+
+def build_manifest(markdown, source_path, detected_from, metadata):
+    chapters = split_into_chapters(markdown)
+    tokens = common.estimate_tokens(markdown)
+    size = classify_size(tokens)
+    parts = plan_parts(chapters, target_parts(tokens)) if size == "large" else []
+    return {
+        "title": metadata.get("title") or common.companion_stem(source_path),
+        "author": metadata.get("author", ""),
+        "language": metadata.get("language", ""),
+        "source_path": source_path,
+        "source_stem": common.companion_stem(source_path),
+        "structural_confidence": structural_confidence(chapters, detected_from),
+        "word_count": len(markdown.split()),
+        "token_estimate": tokens,
+        "size_class": size,
+        "chapters": chapters,
+        "parts": parts,
+    }
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Ingest a book into normalized Markdown + manifest.")
+    p.add_argument("source")
+    p.add_argument("--out", required=True)
+    args = p.parse_args(argv)
+    markdown, detected, meta = convert_to_markdown(args.source)
+    manifest = build_manifest(markdown, args.source, detected, meta)
+    os.makedirs(args.out, exist_ok=True)
+    with open(os.path.join(args.out, "normalized.md"), "w", encoding="utf-8") as f:
+        f.write(markdown)
+    with open(os.path.join(args.out, "manifest.json"), "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False)
+    print(json.dumps({"size_class": manifest["size_class"],
+                      "chapters": len(manifest["chapters"]),
+                      "structural_confidence": manifest["structural_confidence"]}))
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/book-companion/scripts/resolve_book.py
+++ b/.claude/skills/book-companion/scripts/resolve_book.py
@@ -1,0 +1,68 @@
+"""Resolve a book title to a source file path via calibredb. Stdlib only."""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+DEFAULT_LIBRARY = os.environ.get("CALIBRE_LIBRARY", os.path.expanduser("~/Calibre Library"))
+_PREFERENCE = (".epub", ".md", ".txt", ".mobi")
+
+def choose_format(formats):
+    for ext in _PREFERENCE:
+        for path in formats:
+            if path.lower().endswith(ext):
+                return path
+    return None
+
+def parse_candidates(calibredb_json):
+    rows = json.loads(calibredb_json or "[]")
+    out = []
+    for row in rows:
+        formats = row.get("formats") or []
+        out.append({
+            "id": row.get("id"),
+            "title": row.get("title"),
+            "authors": row.get("authors"),
+            "formats": formats,
+            "source": choose_format(formats),
+        })
+    return out
+
+def _calibredb_runner(library):
+    def run(title):
+        return subprocess.check_output([
+            "calibredb", "list",
+            "--search", 'title:"%s"' % title,
+            "--fields", "title,authors,formats",
+            "--for-machine",
+            "--with-library", library,
+        ], text=True)
+    return run
+
+def resolve(title, runner):
+    candidates = parse_candidates(runner(title))
+    if not candidates:
+        return {"status": "not_found"}
+    if len(candidates) == 1:
+        c = candidates[0]
+        if c["source"] is None:
+            return {"status": "not_found"}
+        return {"status": "resolved", "source": c["source"],
+                "title": c["title"], "authors": c["authors"]}
+    return {"status": "ambiguous", "candidates": [
+        {"id": c["id"], "title": c["title"], "authors": c["authors"], "source": c["source"]}
+        for c in candidates]}
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Resolve a book title via calibredb.")
+    p.add_argument("title")
+    p.add_argument("--library", default=DEFAULT_LIBRARY)
+    args = p.parse_args(argv)
+    result = resolve(args.title, runner=_calibredb_runner(args.library))
+    json.dump(result, sys.stdout, indent=2)
+    print()
+    return 0 if result["status"] == "resolved" else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/book-companion/scripts/verify_companion.py
+++ b/.claude/skills/book-companion/scripts/verify_companion.py
@@ -1,0 +1,97 @@
+"""Mechanical verification gate for a generated companion. Stdlib only.
+
+Judgment checks (spoiler leakage, explanation quality) are the LLM's job and are
+NOT performed here. This script only checks what is mechanically decidable.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+_BOLD = re.compile(r"\*\*([^*]+?)\*\*")
+
+def check_header_clean(companion_text):
+    stripped = companion_text.lstrip()
+    return stripped.startswith("#")
+
+def _section(companion_text, name):
+    pat = re.compile(r"^##\s+.*%s.*$" % re.escape(name), re.MULTILINE | re.IGNORECASE)
+    m = pat.search(companion_text)
+    if not m:
+        return ""
+    nxt = re.compile(r"^##\s+", re.MULTILINE).search(companion_text, m.end())
+    return companion_text[m.end():(nxt.start() if nxt else len(companion_text))]
+
+def extract_character_names(companion_text):
+    section = _section(companion_text, "Character Dictionary")
+    return [m.group(1).strip() for m in _BOLD.finditer(section)]
+
+def chapter_coverage(companion_text, manifest):
+    chapters = manifest.get("chapters", [])
+    missing = []
+    for ch in chapters:
+        idx = ch.get("index")
+        title = (ch.get("title") or "").strip()
+        by_num = re.search(r"\bChapter\s+%s\b" % re.escape(str(idx)), companion_text)
+        by_title = title and title in companion_text
+        if not (by_num or by_title):
+            missing.append(idx)
+    return {"total": len(chapters), "covered": len(chapters) - len(missing), "missing": missing}
+
+def names_missing_from_source(names, source_text):
+    return [n for n in names if n not in source_text]
+
+def phrases_uncovered(companion_text, foreign_phrases):
+    return [p for p in foreign_phrases if p not in companion_text]
+
+def _paths_ok(expected_stem, written_paths):
+    if not written_paths:
+        return False
+    want = expected_stem + ".companion.md"
+    return all(os.path.basename(p) == want for p in written_paths)
+
+def verify(companion_text, source_text, manifest, candidates, expected_stem, written_paths):
+    cov = chapter_coverage(companion_text, manifest)
+    names = extract_character_names(companion_text)
+    checks = {
+        "header_clean": check_header_clean(companion_text),
+        "chapter_coverage": cov,
+        "names_missing_from_source": names_missing_from_source(names, source_text),
+        "phrases_uncovered": phrases_uncovered(
+            companion_text, candidates.get("foreign_phrases", [])),
+        "filename_ok": _paths_ok(expected_stem, written_paths),
+    }
+    # Hard gates only: clean header, full chapter coverage, filename/paths correct.
+    # names_missing_from_source and phrases_uncovered are ADVISORY — they stay in checks
+    # for the LLM's judgment self-check (step 8) but do not affect ok.
+    ok = (checks["header_clean"]
+          and not cov["missing"]
+          and checks["filename_ok"])
+    return {"ok": ok, "checks": checks}
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Verify a generated companion (mechanical checks).")
+    p.add_argument("--companion", required=True)
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--source", required=True)
+    p.add_argument("--candidates", required=True)
+    p.add_argument("--stem", required=True)
+    p.add_argument("--paths", default="")
+    args = p.parse_args(argv)
+    with open(args.companion, encoding="utf-8", errors="replace") as f:
+        companion = f.read()
+    with open(args.source, encoding="utf-8", errors="replace") as f:
+        source = f.read()
+    with open(args.manifest, encoding="utf-8") as f:
+        manifest = json.load(f)
+    with open(args.candidates, encoding="utf-8") as f:
+        candidates = json.load(f)
+    paths = [s for s in args.paths.split(",") if s]
+    report = verify(companion, source, manifest, candidates, args.stem, paths)
+    json.dump(report, sys.stdout, indent=2, ensure_ascii=False)
+    print()
+    return 0 if report["ok"] else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/book-companion/scripts/write_companion.py
+++ b/.claude/skills/book-companion/scripts/write_companion.py
@@ -1,0 +1,36 @@
+"""Write the companion to its two destinations with the exact-match filename."""
+import argparse
+import os
+import sys
+
+import common
+
+def write_both(content, source_path, repo_companions_dir, book_folder):
+    name = common.companion_filename(source_path)
+    paths = []
+    for d in (repo_companions_dir, book_folder):
+        os.makedirs(d, exist_ok=True)
+        path = os.path.join(d, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        paths.append(os.path.abspath(path))
+    with open(paths[0], "rb") as f1, open(paths[1], "rb") as f2:
+        if f1.read() != f2.read():
+            raise ValueError("written companions differ between destinations")
+    return paths
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Write companion to repo + book folder.")
+    p.add_argument("--content", required=True)
+    p.add_argument("--source", required=True)
+    p.add_argument("--repo-companions", required=True)
+    p.add_argument("--book-folder", required=True)
+    args = p.parse_args(argv)
+    with open(args.content, encoding="utf-8", errors="replace") as f:
+        content = f.read()
+    for pth in write_both(content, args.source, args.repo_companions, args.book_folder):
+        print(pth)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/book-companion/tests/test_common.py
+++ b/.claude/skills/book-companion/tests/test_common.py
@@ -1,0 +1,24 @@
+import os, sys, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import common
+
+class TestCommon(unittest.TestCase):
+    def test_stem_strips_only_final_extension(self):
+        self.assertEqual(
+            common.companion_stem("/lib/Stranger in a Strange Land - Robert A. Heinlein.epub"),
+            "Stranger in a Strange Land - Robert A. Heinlein")
+
+    def test_stem_keeps_internal_dots(self):
+        self.assertEqual(common.companion_stem("/x/A. B. Author - Vol.2.txt"), "A. B. Author - Vol.2")
+
+    def test_filename_appends_companion_md(self):
+        self.assertEqual(common.companion_filename("/x/Middlemarch.epub"), "Middlemarch.companion.md")
+
+    def test_estimate_tokens_chars_over_four(self):
+        self.assertEqual(common.estimate_tokens("a" * 400), 100)
+
+    def test_estimate_tokens_minimum_one(self):
+        self.assertEqual(common.estimate_tokens(""), 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/book-companion/tests/test_harvest.py
+++ b/.claude/skills/book-companion/tests/test_harvest.py
@@ -1,0 +1,36 @@
+import os, sys, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import harvest_candidates as hc
+
+MD = (
+    "# One\n"
+    "> An epigraph line\n\n"
+    "Casaubon spoke of *incompatibilité d'humeur* to Dorothea.\n"
+    "Will Ladislaw met Dorothea. Will Ladislaw left.\n"
+    "Naïve readers note the café.\n"
+)
+
+class TestHarvest(unittest.TestCase):
+    def test_emphasis_phrase_captured(self):
+        out = hc.harvest(MD)
+        self.assertIn("incompatibilité d'humeur", out["foreign_phrases"])
+
+    def test_accented_run_captured(self):
+        out = hc.harvest(MD)
+        joined = " ".join(out["foreign_phrases"])
+        self.assertTrue("Naïve" in joined or "café" in joined)
+
+    def test_epigraph_captured(self):
+        out = hc.harvest(MD)
+        self.assertIn("An epigraph line", out["epigraphs"])
+
+    def test_repeated_proper_noun(self):
+        out = hc.harvest(MD)
+        self.assertIn("Will Ladislaw", out["proper_nouns"])
+
+    def test_single_occurrence_not_a_proper_noun(self):
+        out = hc.harvest("# T\nNaumann appeared once.\n")
+        self.assertNotIn("Naumann", out["proper_nouns"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/book-companion/tests/test_ingest_core.py
+++ b/.claude/skills/book-companion/tests/test_ingest_core.py
@@ -1,0 +1,82 @@
+import os, sys, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import ingest
+
+MD = "# Chapter 1\nalpha\n\n# Chapter 2\nbeta\n\n# Chapter 3\ngamma\n"
+
+class TestIngestCore(unittest.TestCase):
+    def test_split_counts_and_titles(self):
+        chs = ingest.split_into_chapters(MD)
+        self.assertEqual([c["title"] for c in chs], ["Chapter 1", "Chapter 2", "Chapter 3"])
+        self.assertEqual(chs[0]["index"], 1)
+
+    def test_split_offsets_are_contiguous_and_cover_text(self):
+        chs = ingest.split_into_chapters(MD)
+        self.assertEqual(chs[0]["char_start"], 0)
+        self.assertEqual(chs[-1]["char_end"], len(MD))
+        for a, b in zip(chs, chs[1:]):
+            self.assertEqual(a["char_end"], b["char_start"])
+
+    def test_split_no_headings_yields_single_full_text(self):
+        chs = ingest.split_into_chapters("just prose, no headings")
+        self.assertEqual(len(chs), 1)
+        self.assertEqual(chs[0]["title"], "Full Text")
+
+    def test_confidence_high_with_three_heading_chapters(self):
+        chs = ingest.split_into_chapters(MD)
+        self.assertEqual(ingest.structural_confidence(chs, "headings"), "high")
+
+    def test_confidence_low_for_fallback(self):
+        self.assertEqual(ingest.structural_confidence([{"index": 1}], "none"), "low")
+
+    def test_classify_size(self):
+        self.assertEqual(ingest.classify_size(100), "small")
+        self.assertEqual(ingest.classify_size(60000), "large")
+
+    def test_target_parts_bounds(self):
+        self.assertEqual(ingest.target_parts(100), 2)
+        self.assertEqual(ingest.target_parts(10_000_000), 12)
+
+    def test_plan_parts_balances_contiguously(self):
+        chs = ingest.split_into_chapters(MD)
+        parts = ingest.plan_parts(chs, 2)
+        self.assertEqual(len(parts), 2)
+        self.assertEqual(parts[0]["chapter_range"][0], 1)
+        self.assertEqual(parts[-1]["chapter_range"][1], 3)
+        self.assertEqual(parts[0]["char_start"], 0)
+        self.assertEqual(parts[-1]["char_end"], len(MD))
+
+    def test_split_includes_preamble_before_first_heading(self):
+        text = "Front matter.\n\n# Chapter 1\nalpha\n\n# Chapter 2\nbeta\n"
+        chs = ingest.split_into_chapters(text)
+        self.assertEqual(chs[0]["char_start"], 0)
+        self.assertEqual(chs[-1]["char_end"], len(text))
+        for a, b in zip(chs, chs[1:]):
+            self.assertEqual(a["char_end"], b["char_start"])
+
+    def test_confidence_low_for_two_headings(self):
+        text = "# A\nx\n\n# B\ny\n"
+        chs = ingest.split_into_chapters(text)
+        self.assertEqual(ingest.structural_confidence(chs, "headings"), "low")
+
+    def test_choose_heading_level_returns_most_frequent(self):
+        text = (
+            "## Book I\n### Chapter 1\na\n### Chapter 2\nb\n\n"
+            "## Book II\n### Chapter 3\nc\n### Chapter 4\nd\n"
+        )
+        self.assertEqual(ingest._choose_heading_level(text), 3)
+
+    def test_chapter_level_picks_most_frequent_heading(self):
+        text = (
+            "## Book I\n### Chapter 1\na\n### Chapter 2\nb\n\n"
+            "## Book II\n### Chapter 3\nc\n### Chapter 4\nd\n"
+        )
+        chapters = ingest.split_into_chapters(text)
+        self.assertEqual(len(chapters), 4)
+        self.assertEqual(
+            [c["title"] for c in chapters],
+            ["Chapter 1", "Chapter 2", "Chapter 3", "Chapter 4"],
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/book-companion/tests/test_ingest_manifest.py
+++ b/.claude/skills/book-companion/tests/test_ingest_manifest.py
@@ -1,0 +1,67 @@
+import os, sys, json, tempfile, subprocess, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import ingest
+
+MD = "# Chapter 1\nalpha\n\n# Chapter 2\nbeta\n\n# Chapter 3\ngamma\n"
+
+class TestManifest(unittest.TestCase):
+    def test_manifest_small_has_no_parts(self):
+        man = ingest.build_manifest(MD, "/x/My Book.txt", "headings",
+                                    {"title": "My Book", "author": "A", "language": "en"})
+        self.assertEqual(man["size_class"], "small")
+        self.assertEqual(man["parts"], [])
+        self.assertEqual(man["source_stem"], "My Book")
+        self.assertEqual(len(man["chapters"]), 3)
+        self.assertEqual(man["structural_confidence"], "high")
+
+    def test_manifest_large_has_parts(self):
+        big = "# A\n" + ("x" * 300000) + "\n# B\n" + ("y" * 300000) + "\n"
+        man = ingest.build_manifest(big, "/x/Big.epub", "headings",
+                                    {"title": "Big", "author": "A", "language": "en"})
+        self.assertEqual(man["size_class"], "large")
+        self.assertTrue(len(man["parts"]) >= 2)
+
+    def test_cli_writes_outputs(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "Sample.txt")
+            with open(src, "w") as f:
+                f.write(MD)
+            out = os.path.join(d, "work")
+            os.makedirs(out)
+            rc = subprocess.call([sys.executable,
+                os.path.join(os.path.dirname(__file__), "..", "scripts", "ingest.py"),
+                src, "--out", out])
+            self.assertEqual(rc, 0)
+            self.assertTrue(os.path.exists(os.path.join(out, "normalized.md")))
+            with open(os.path.join(out, "manifest.json")) as f:
+                man = json.load(f)
+            self.assertEqual(man["source_stem"], "Sample")
+
+    def test_convert_strips_inline_html(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "book.md")
+            with open(src, "w") as f:
+                f.write(
+                    '# <span class="se:label">Book</span> One\n\n'
+                    "body <span>x</span> text\n"
+                )
+            markdown, detected, meta = ingest.convert_to_markdown(src)
+            self.assertNotIn("<span", markdown)
+            chapters = ingest.split_into_chapters(markdown)
+            self.assertEqual(chapters[0]["title"], "Book One")
+
+    @unittest.skipUnless(__import__("shutil").which("pandoc"), "pandoc not installed")
+    def test_epub_conversion_roundtrip(self):
+        with tempfile.TemporaryDirectory() as d:
+            md = os.path.join(d, "src.md")
+            epub = os.path.join(d, "Fixture Book.epub")
+            with open(md, "w") as f:
+                f.write("# One\nalpha\n\n# Two\nbeta\n")
+            subprocess.check_call(["pandoc", md, "-o", epub,
+                                   "--metadata", "title=Fixture Book"])
+            markdown, detected, meta = ingest.convert_to_markdown(epub)
+            self.assertIn("One", markdown)
+            self.assertEqual(detected, "headings")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/book-companion/tests/test_resolve_book.py
+++ b/.claude/skills/book-companion/tests/test_resolve_book.py
@@ -1,0 +1,49 @@
+import os, sys, json, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import resolve_book as rb
+
+ONE = json.dumps([{
+    "id": 48, "title": "Stranger in a Strange Land", "authors": "Robert A. Heinlein",
+    "formats": ["/lib/SiaSL - Robert A. Heinlein.mobi", "/lib/SiaSL - Robert A. Heinlein.epub"],
+}])
+MANY = json.dumps([
+    {"id": 1, "title": "Hamlet", "authors": "Shakespeare", "formats": ["/l/Hamlet.epub"]},
+    {"id": 2, "title": "Hamlet (annotated)", "authors": "Shakespeare", "formats": ["/l/Hamlet2.epub"]},
+])
+ONE_NO_FORMAT = json.dumps([{
+    "id": 99, "title": "PDF Only Book", "authors": "Unknown",
+    "formats": ["/lib/pdf_only.pdf"],
+}])
+
+class TestResolve(unittest.TestCase):
+    def test_choose_format_prefers_epub(self):
+        self.assertEqual(rb.choose_format(["/a/x.mobi", "/a/x.epub", "/a/x.md"]), "/a/x.epub")
+
+    def test_choose_format_falls_back_to_md_then_txt(self):
+        self.assertEqual(rb.choose_format(["/a/x.mobi", "/a/x.md"]), "/a/x.md")
+        self.assertEqual(rb.choose_format(["/a/x.txt"]), "/a/x.txt")
+
+    def test_choose_format_none(self):
+        self.assertIsNone(rb.choose_format(["/a/x.pdf"]))
+
+    def test_resolve_single_match(self):
+        out = rb.resolve("Stranger", runner=lambda t: ONE)
+        self.assertEqual(out["status"], "resolved")
+        self.assertEqual(out["source"], "/lib/SiaSL - Robert A. Heinlein.epub")
+
+    def test_resolve_ambiguous(self):
+        out = rb.resolve("Hamlet", runner=lambda t: MANY)
+        self.assertEqual(out["status"], "ambiguous")
+        self.assertEqual(len(out["candidates"]), 2)
+
+    def test_resolve_not_found(self):
+        out = rb.resolve("Nope", runner=lambda t: "[]")
+        self.assertEqual(out["status"], "not_found")
+
+    def test_resolve_single_match_no_usable_format(self):
+        """Single candidate with only PDF (unsupported format) should return not_found."""
+        out = rb.resolve("PDF Only", runner=lambda t: ONE_NO_FORMAT)
+        self.assertEqual(out["status"], "not_found")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/book-companion/tests/test_verify.py
+++ b/.claude/skills/book-companion/tests/test_verify.py
@@ -1,0 +1,100 @@
+import os, sys, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import verify_companion as vc
+
+GOOD = (
+    "## 1. Quick Orientation\nWorld stuff.\n\n"
+    "## 3. Character Dictionary\n"
+    "**Dorothea Brooke** — a young woman.\n\n"
+    "## 2. Chapter-by-Chapter Plot\n"
+    "### Chapter 1\nalpha\n### Chapter 2\nbeta\n\n"
+    "## 6. Foreign-Language Phrases\n**incompatibilité d'humeur** — incompatibility.\n"
+)
+MANIFEST = {"chapters": [{"index": 1, "title": "Chapter 1"}, {"index": 2, "title": "Chapter 2"}]}
+SOURCE = "Dorothea Brooke walked. incompatibilité d'humeur."
+CANDS = {"foreign_phrases": ["incompatibilité d'humeur"]}
+
+class TestVerify(unittest.TestCase):
+    def test_header_clean_true(self):
+        self.assertTrue(vc.check_header_clean(GOOD))
+
+    def test_header_clean_false_on_stray_prefix(self):
+        self.assertFalse(vc.check_header_clean("Ha## 1. Quick Orientation\n"))
+
+    def test_extract_character_names(self):
+        self.assertIn("Dorothea Brooke", vc.extract_character_names(GOOD))
+
+    def test_chapter_coverage_full(self):
+        cov = vc.chapter_coverage(GOOD, MANIFEST)
+        self.assertEqual(cov["covered"], 2)
+        self.assertEqual(cov["missing"], [])
+
+    def test_chapter_coverage_missing(self):
+        m = {"chapters": [{"index": 1, "title": "Chapter 1"},
+                          {"index": 2, "title": "Chapter 2"},
+                          {"index": 3, "title": "Chapter 3"}]}
+        cov = vc.chapter_coverage(GOOD, m)
+        self.assertEqual(cov["missing"], [3])
+
+    def test_names_missing_from_source(self):
+        self.assertEqual(vc.names_missing_from_source(["Dorothea Brooke"], SOURCE), [])
+        self.assertEqual(vc.names_missing_from_source(["Casobon"], SOURCE), ["Casobon"])
+
+    def test_phrases_uncovered(self):
+        self.assertEqual(vc.phrases_uncovered(GOOD, CANDS["foreign_phrases"]), [])
+        self.assertEqual(vc.phrases_uncovered(GOOD, ["dolce far niente"]), ["dolce far niente"])
+
+    def test_verify_ok(self):
+        report = vc.verify(GOOD, SOURCE, MANIFEST, CANDS, "Middlemarch",
+                           ["/a/Middlemarch.companion.md", "/b/Middlemarch.companion.md"])
+        self.assertTrue(report["ok"])
+
+    def test_verify_fails_on_bad_stem(self):
+        report = vc.verify(GOOD, SOURCE, MANIFEST, CANDS, "Middlemarch",
+                           ["/a/Wrong.companion.md"])
+        self.assertFalse(report["ok"])
+
+    def test_verify_ok_despite_advisory_noise(self):
+        # Bold group-label not present in source, plus an uncovered foreign-phrase candidate.
+        # These are advisory: ok must still be True when the hard gates pass.
+        companion = (
+            "## 1. Quick Orientation\nWorld stuff.\n\n"
+            "## 3. Character Dictionary\n"
+            "**Dr. Sprague & Mr. Wrench & Mr. Toller** — physicians.\n\n"  # not in SOURCE
+            "## 2. Chapter-by-Chapter Plot\n"
+            "### Chapter 1\nalpha\n### Chapter 2\nbeta\n\n"
+            "## 6. Foreign-Language Phrases\n**dolce far niente** — sweetness.\n"
+        )
+        # Source does NOT contain the bold group label
+        source = "Dr. Sprague walked. Some English text."
+        manifest = {"chapters": [{"index": 1, "title": "Chapter 1"},
+                                  {"index": 2, "title": "Chapter 2"}]}
+        # Candidate phrase is NOT present in companion text
+        cands = {"foreign_phrases": ["incompatibilité d'humeur"]}
+        report = vc.verify(companion, source, manifest, cands, "Middlemarch",
+                           ["/a/Middlemarch.companion.md"])
+        self.assertTrue(report["ok"])
+        self.assertTrue(len(report["checks"]["names_missing_from_source"]) > 0,
+                        "names_missing_from_source should be non-empty (advisory)")
+        self.assertTrue(len(report["checks"]["phrases_uncovered"]) > 0,
+                        "phrases_uncovered should be non-empty (advisory)")
+
+    def test_verify_fails_on_missing_chapter(self):
+        manifest_with_extra = {"chapters": [
+            {"index": 1, "title": "Chapter 1"},
+            {"index": 2, "title": "Chapter 2"},
+            {"index": 3, "title": "Chapter 3"},
+        ]}
+        # GOOD only covers chapters 1 and 2
+        report = vc.verify(GOOD, SOURCE, manifest_with_extra, CANDS, "Middlemarch",
+                           ["/a/Middlemarch.companion.md"])
+        self.assertFalse(report["ok"])
+
+    def test_verify_fails_on_dirty_header(self):
+        dirty = "Ha## 1. Quick Orientation\nWorld stuff.\n\n" + GOOD[GOOD.index("## 3"):]
+        report = vc.verify(dirty, SOURCE, MANIFEST, CANDS, "Middlemarch",
+                           ["/a/Middlemarch.companion.md"])
+        self.assertFalse(report["ok"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/book-companion/tests/test_write.py
+++ b/.claude/skills/book-companion/tests/test_write.py
@@ -1,0 +1,18 @@
+import os, sys, tempfile, unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import write_companion as wc
+
+class TestWrite(unittest.TestCase):
+    def test_writes_identical_named_copies(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = os.path.join(d, "companions"); book = os.path.join(d, "book")
+            os.makedirs(repo); os.makedirs(book)
+            paths = wc.write_both("BODY", "/lib/My Book - Author.epub", repo, book)
+            self.assertEqual(len(paths), 2)
+            for pth in paths:
+                self.assertTrue(pth.endswith("My Book - Author.companion.md"))
+                with open(pth) as f:
+                    self.assertEqual(f.read(), "BODY")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ _*.po
 .vscode
 .env
 CLAUDE.md
+configuration.lua
+companions/*.companion.md
+.superpowers/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ The Assistant plugin adds AI-powered buttons (Wikipedia, Term X-Ray, Dictionary,
 - Try the pre-made buttons for quick analysis
 - Add your own custom prompts for specialized tasks
 
+## Book Companion
+
+The Book Companion feature lets you attach a pre-authored, comprehension-first reference to any book. When a `.companion.md` sidecar file is placed beside a book on the device, a **Book Companion** button appears in the highlight and dictionary popups for that book. Tapping it asks the AI to explain the highlighted passage using the companion as its primary, authoritative source — prioritizing characters, allusions, historical context, and untranslated phrases — while respecting your current reading progress so nothing ahead is spoiled.
+
+Companions are generated from a Calibre library, an ePub, or a plain-text source using the `book-companion` skill included in this repository. The generator runs an `ingest → harvest → write → verify` pipeline of stdlib-only Python scripts and produces a `<book-stem>.companion.md` file that is written both to the repository's `companions/` folder and beside the source book. You can also configure a dedicated provider and model for companion queries, separate from the plugin's global AI Provider. For the full details — sidecar naming and placement, prompt behavior, provider selection, and how to run the generator — see [docs/book-companion.md](docs/book-companion.md).
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/api_handlers/anthropic.lua
+++ b/api_handlers/anthropic.lua
@@ -2,39 +2,9 @@ local BaseHandler = require("api_handlers.base")
 local json = require("json")
 local koutil = require("util")
 local logger = require("logger")
+local AnthropicMessages = require("api_handlers.anthropic_messages")
 
 local AnthropicHandler = BaseHandler:new()
-
-local function prepare_anthropic_messages(message_history)
-    local anthropic_messages = {}
-    local system_content = ""
-    
-    -- Extract and concatenate all system prompts
-    for i, msg in ipairs(message_history) do
-        if msg.role == "system" then
-            system_content = system_content .. msg.content .. "\n\n"
-        end
-    end
-
-    -- Remove trailing newlines
-    system_content = system_content:gsub("\n\n$", "")
-    
-    -- Process non-system messages (user and assistant)
-    for i, msg in ipairs(message_history) do
-        if msg.role ~= "system" then
-            table.insert(anthropic_messages, {
-                role = msg.role,
-                content = msg.content
-            })
-        end
-    end
-    
-    -- Return structured data for Anthropic API
-    return {
-        messages = anthropic_messages,
-        system = system_content
-    }
-end
 
 local function extract_text_from_content(content_blocks)
     if type(content_blocks) ~= "table" then
@@ -56,7 +26,7 @@ end
 
 function AnthropicHandler:query(message_history, anthropic_settings)
     
-    local requestBodyTable = prepare_anthropic_messages(message_history)
+    local requestBodyTable = AnthropicMessages.prepare(message_history)
     requestBodyTable.model = anthropic_settings.model
     requestBodyTable.max_tokens = koutil.tableGetValue(anthropic_settings, "additional_parameters", "max_tokens")
     requestBodyTable.stream = koutil.tableGetValue(anthropic_settings, "additional_parameters", "stream") or false

--- a/api_handlers/anthropic_messages.lua
+++ b/api_handlers/anthropic_messages.lua
@@ -1,0 +1,47 @@
+-- Pure transform from the plugin's message_history into Anthropic's
+-- { messages, system } request shape. LuaJIT-compatible, no external deps.
+--
+-- Back-compat: when no system message carries `cache = true`, `system` is the
+-- newline-joined string the handler has always sent. When any system message is
+-- flagged, `system` becomes an array of text blocks and flagged blocks receive
+-- cache_control = { type = "ephemeral" } for Anthropic prompt caching.
+local M = {}
+
+function M.prepare(message_history)
+  local system_msgs = {}
+  local messages = {}
+  local has_cache = false
+
+  for _, msg in ipairs(message_history) do
+    if msg.role == "system" then
+      table.insert(system_msgs, { text = msg.content, cache = msg.cache == true })
+      if msg.cache == true then
+        has_cache = true
+      end
+    else
+      table.insert(messages, { role = msg.role, content = msg.content })
+    end
+  end
+
+  local system
+  if has_cache then
+    system = {}
+    for _, sm in ipairs(system_msgs) do
+      local block = { type = "text", text = sm.text }
+      if sm.cache then
+        block.cache_control = { type = "ephemeral" }
+      end
+      table.insert(system, block)
+    end
+  else
+    local parts = {}
+    for _, sm in ipairs(system_msgs) do
+      table.insert(parts, sm.text)
+    end
+    system = table.concat(parts, "\n\n")
+  end
+
+  return { messages = messages, system = system }
+end
+
+return M

--- a/assistant_book_filter.lua
+++ b/assistant_book_filter.lua
@@ -1,0 +1,31 @@
+-- Decide whether a prompt's `book_filter` matches the current book's properties.
+-- Pure module: no KOReader dependencies, LuaJIT-compatible.
+-- A filter supports `title_contains` and `author_contains` (case-insensitive
+-- substring). All present conditions must match (AND). A nil/empty filter matches.
+local M = {}
+
+local function contains(haystack, needle)
+  if not needle or needle == "" then
+    return true
+  end
+  if type(haystack) ~= "string" then
+    return false
+  end
+  return string.find(haystack:lower(), needle:lower(), 1, true) ~= nil
+end
+
+function M.matches(filter, props)
+  if not filter then
+    return true
+  end
+  props = props or {}
+  if not contains(props.title, filter.title_contains) then
+    return false
+  end
+  if not contains(props.authors, filter.author_contains) then
+    return false
+  end
+  return true
+end
+
+return M

--- a/assistant_companion.lua
+++ b/assistant_companion.lua
@@ -1,0 +1,54 @@
+-- Loads a per-book reference companion sidecar file.
+-- Pure module: no KOReader dependencies, LuaJIT-compatible.
+-- Exports: getCompanionPath, loadCompanion
+local M = {}
+
+-- Derive the sidecar path: same directory, filename stem + ".companion.md".
+-- "/Books/Middlemarch.epub" -> "/Books/Middlemarch.companion.md"
+function M.getCompanionPath(book_filepath)
+  if not book_filepath or book_filepath == "" then
+    return nil
+  end
+  -- Strip a trailing extension only (a final dot followed by non-separator chars).
+  local stem = book_filepath:gsub("%.[^./\\]+$", "")
+  return stem .. ".companion.md"
+end
+
+-- Read the companion sidecar for a book. Returns its contents, or nil if the
+-- file is missing, unreadable, or empty. Never throws.
+function M.loadCompanion(book_filepath)
+  local path = M.getCompanionPath(book_filepath)
+  if not path then
+    return nil
+  end
+  local f = io.open(path, "r")
+  if not f then
+    return nil
+  end
+  local content = f:read("*a")
+  f:close()
+  -- read("*a") on a valid handle always returns a string; treat empty as absent.
+  if content == "" then
+    return nil
+  end
+  return content
+end
+
+-- Cheap existence check: true if the book has a non-empty companion sidecar.
+-- Mirrors loadCompanion's "empty == absent" rule without reading the whole file.
+-- Used to decide whether to surface companion prompts for the current book.
+function M.hasCompanion(book_filepath)
+  local path = M.getCompanionPath(book_filepath)
+  if not path then
+    return false
+  end
+  local f = io.open(path, "r")
+  if not f then
+    return false
+  end
+  local first = f:read(1)
+  f:close()
+  return first ~= nil
+end
+
+return M

--- a/assistant_dialog.lua
+++ b/assistant_dialog.lua
@@ -14,6 +14,9 @@ local T = require("ffi/util").template
 local Trapper = require("ui/trapper")
 local Prompts = require("assistant_prompts")
 local koutil = require("util")
+local Companion = require("assistant_companion")
+local ProviderOverride = require("assistant_provider_override")
+local ProviderContext = require("assistant_provider_context")
 local Device = require("device")
 local Screen = Device.screen
 local CheckButton = require("ui/widget/checkbutton")
@@ -56,8 +59,10 @@ function AssistantDialog:_formatUserPrompt(user_prompt, highlightedText, user_in
   -- Calculate progress if placeholder is present  
   local formatted_progress = nil
   if user_prompt:find("{progress}", 1, true) then
-      local success, doc_settings = pcall(function() 
-          return require("docsettings"):open(self.assistant.ui.document.file) 
+      -- Fallback so {progress} is never left literal if the setting can't be read.
+      formatted_progress = "0"
+      local success, doc_settings = pcall(function()
+          return require("docsettings"):open(self.assistant.ui.document.file)
       end)
       if success and doc_settings then
           local percent_finished = doc_settings:readSetting("percent_finished") or 0
@@ -505,6 +510,26 @@ function AssistantDialog:showCustomPrompt(highlightedText, prompt_index, user_in
   highlightedText = highlightedText:gsub("\n", "\n\n") -- ensure newlines are doubled (LLM presumes markdown input)
 
   local user_content = self:_formatUserPrompt(koutil.tableGetValue(prompt_config, "user_prompt"), highlightedText, user_input or "")
+
+  -- For opted-in prompts, prepend the passage around the highlight so the model can
+  -- resolve local references. Kept in the user message (variable, never cached).
+  if koutil.tableGetValue(prompt_config, "use_surrounding")
+     and self.assistant.ui and self.assistant.ui.highlight
+     and self.assistant.ui.highlight.getSelectedWordContext then
+    local words = koutil.tableGetValue(self.CONFIGURATION, "features", "surrounding_context_words") or 90
+    local ok, prev, after = pcall(function()
+      return self.assistant.ui.highlight:getSelectedWordContext(words)
+    end)
+    if ok and ((prev and prev ~= "") or (after and after ~= "")) then
+      local passage = (prev or "") .. " «" .. highlightedText .. "» " .. (after or "")
+      local surrounding = "Passage around the highlight (the highlighted part is between « and »):\n\n"
+        .. passage
+        .. "\n\nUse the surrounding text only to understand context; focus your explanation on the highlighted text: \""
+        .. highlightedText .. "\".\n\n"
+      user_content = surrounding .. user_content
+    end
+  end
+
   local system_prompt = koutil.tableGetValue(prompt_config, "system_prompt") or koutil.tableGetValue(Prompts, "assistant_prompts", "default", "system_prompt")
 
   if self.assistant.settings:readSetting("auto_prompt_suggest", false) then
@@ -518,14 +543,35 @@ function AssistantDialog:showCustomPrompt(highlightedText, prompt_index, user_in
       role = "system",
       content = system_prompt,
     },
-    {
-      role = "user",
-      content = user_content,
-      user_input = user_input,
-    }
   }
-  
-  local answer, err = self.querier:query(message_history, string.format("🌐 Loading for %s ...", title or prompt_index))
+
+  -- Inject the per-book reference companion as a cacheable system block (opt-in per prompt).
+  -- The cache breakpoint sits on this block, so it also caches the instructions block above it;
+  -- keep both stable per session and keep variable content (highlight, progress) in the user block.
+  if koutil.tableGetValue(prompt_config, "use_companion") then
+    local doc = self.assistant.ui and self.assistant.ui.document
+    local book_file = doc and doc.file
+    local companion = book_file and Companion.loadCompanion(book_file) or nil
+    if companion then
+      table.insert(message_history, {
+        role = "system",
+        content = companion,
+        cache = true,
+      })
+    end
+  end
+
+  table.insert(message_history, {
+    role = "user",
+    content = user_content,
+    user_input = user_input,
+  })
+
+  local prompt_provider, prompt_model =
+    ProviderContext.resolveForPrompt(self.assistant.settings, prompt_config, self.assistant.CONFIGURATION)
+  local answer, err = ProviderOverride.runWithProvider(self.querier, prompt_provider, prompt_model, function()
+    return self.querier:query(message_history, string.format("🌐 Loading for %s ...", title or prompt_index))
+  end)
   if err then
     self.querier:showError(err)
     return

--- a/assistant_model_picker.lua
+++ b/assistant_model_picker.lua
@@ -27,6 +27,7 @@ local T = require("ffi/util").template
 local Screen = require("device").screen
 local logger = require("logger")
 local assistant_utils = require("assistant_utils")
+local ProviderContext = require("assistant_provider_context")
 
 -- Forward declarations
 local showPickerDialog, showManualInput
@@ -83,23 +84,14 @@ local function fetchOpenRouterModels(list_url)
     return models
 end
 
---- Save selected model to settings and apply to current session
-local function saveModelSelection(assistant, model_id)
-    local provider_name = assistant.querier.provider_name
-    assistant.settings:saveSetting("openrouter_model_" .. provider_name, model_id)
-    assistant.querier.provider_settings.model = model_id
-    assistant.updated = true
+--- Save selected model to settings via the active selection context.
+local function saveModelSelection(context, model_id)
+    context:saveModel(context:selectedProvider(), model_id)
 end
 
---- Reset model override — revert to configuration.lua default
-local function resetModelSelection(assistant)
-    local provider_name = assistant.querier.provider_name
-    assistant.settings:delSetting("openrouter_model_" .. provider_name)
-    -- Restore from CONFIGURATION
-    local config_model = koutil.tableGetValue(
-        assistant.CONFIGURATION, "provider_settings", provider_name, "model")
-    assistant.querier.provider_settings.model = config_model
-    assistant.updated = true
+--- Reset model override — revert to configuration.lua default.
+local function resetModelSelection(context)
+    context:resetModel(context:selectedProvider())
 end
 
 -- Model picker dialog (extends InputDialog following SettingsDialog pattern)
@@ -111,6 +103,7 @@ local ModelPickerDialog = InputDialog:extend{
     close_callback = nil,
     search_query = "",
     page = 1,
+    context = nil,
 }
 
 function ModelPickerDialog:init()
@@ -119,8 +112,7 @@ function ModelPickerDialog:init()
     local fixed_height = Screen:scaleBySize(135) + 2*Size.margin.default -- title bar, buttons row, etc
     local MODELS_PER_PAGE = math.max(5, math.floor((Screen:getHeight() - fixed_height) / item_height))
 
-    local current_model = koutil.tableGetValue(
-        self.assistant, "querier", "provider_settings", "model") or ""
+    local current_model = self.context:selectedModel() or ""
 
     local model_count = #self.models
     local total_pages = math.max(1, math.ceil(model_count / MODELS_PER_PAGE))
@@ -216,7 +208,7 @@ function ModelPickerDialog:init()
         focused = true,
         parent = self,
         button_select_callback = function(btn)
-            saveModelSelection(self.assistant, btn.model_id)
+            saveModelSelection(self.context, btn.model_id)
             UIManager:close(self)
             Notification:notify(T(_("Model: %1"), btn.model_id))
             if self.close_callback then self.close_callback() end
@@ -293,7 +285,7 @@ end
 function ModelPickerDialog:changePage(new_page)
     UIManager:close(self)
     showPickerDialog(self.assistant, self.all_models,
-        self.close_callback, self.search_query, new_page)
+        self.close_callback, self.search_query, new_page, self.context)
 end
 
 function ModelPickerDialog:onSearch()
@@ -310,7 +302,7 @@ function ModelPickerDialog:onSearch()
                 callback = function()
                     UIManager:close(search_dialog)
                     showPickerDialog(self.assistant, self.all_models,
-                        self.close_callback, self.search_query, self.page)
+                        self.close_callback, self.search_query, self.page, self.context)
                 end,
             },
             {
@@ -320,7 +312,7 @@ function ModelPickerDialog:onSearch()
                     local query = search_dialog:getInputText()
                     UIManager:close(search_dialog)
                     showPickerDialog(self.assistant, self.all_models,
-                        self.close_callback, query)
+                        self.close_callback, query, nil, self.context)
                 end,
             },
         }},
@@ -330,15 +322,15 @@ end
 
 function ModelPickerDialog:onManualInput()
     UIManager:close(self)
-    showManualInput(self.assistant, self.close_callback)
+    showManualInput(self.assistant, self.close_callback, self.context)
 end
 
 function ModelPickerDialog:onReset()
-    resetModelSelection(self.assistant)
+    resetModelSelection(self.context)
     UIManager:close(self)
     local config_model = koutil.tableGetValue(
         self.assistant.CONFIGURATION, "provider_settings",
-        self.assistant.querier.provider_name, "model") or "?"
+        self.context:selectedProvider(), "model") or "?"
     Notification:notify(T(_("Model reset: %1"), config_model))
     if self.close_callback then self.close_callback() end
 end
@@ -348,7 +340,7 @@ function ModelPickerDialog:onCloseWidget()
 end
 
 --- Show the model picker dialog with optional search filter and page
-showPickerDialog = function(assistant, all_models, close_callback, search_query, page)
+showPickerDialog = function(assistant, all_models, close_callback, search_query, page, context)
     search_query = search_query or ""
     page = page or 1
     local models = all_models
@@ -372,7 +364,7 @@ showPickerDialog = function(assistant, all_models, close_callback, search_query,
             text = T(_("No models matching \"%1\"."), search_query),
         })
         -- Reopen without filter
-        showPickerDialog(assistant, all_models, close_callback, "")
+        showPickerDialog(assistant, all_models, close_callback, "", nil, context)
         return
     end
 
@@ -383,13 +375,13 @@ showPickerDialog = function(assistant, all_models, close_callback, search_query,
         close_callback = close_callback,
         search_query = search_query,
         page = page,
+        context = context,
     })
 end
 
 --- Show manual model input dialog
-showManualInput = function(assistant, close_callback)
-    local current_model = koutil.tableGetValue(
-        assistant, "querier", "provider_settings", "model") or ""
+showManualInput = function(assistant, close_callback, context)
+    local current_model = context:selectedModel() or ""
     local dialog
     dialog = InputDialog:new{
         title = _("Enter Model ID"),
@@ -408,7 +400,7 @@ showManualInput = function(assistant, close_callback)
                     local model_id = dialog:getInputText()
                     if model_id and koutil.trim(model_id) ~= "" then
                         model_id = koutil.trim(model_id)
-                        saveModelSelection(assistant, model_id)
+                        saveModelSelection(context, model_id)
                         UIManager:close(dialog)
                         Notification:notify(T(_("Model: %1"), model_id))
                         if close_callback then close_callback() end
@@ -421,7 +413,8 @@ showManualInput = function(assistant, close_callback)
 end
 
 --- Main entry point: fetch OpenRouter models and show picker
-local function showOpenRouterModelPicker(assistant, close_callback, list_url)
+local function showOpenRouterModelPicker(assistant, close_callback, list_url, context)
+    context = context or ProviderContext.main(assistant)
     local models, err = fetchOpenRouterModels(list_url)
     if not models then
         if err then
@@ -440,7 +433,7 @@ local function showOpenRouterModelPicker(assistant, close_callback, list_url)
         return
     end
 
-    showPickerDialog(assistant, models, close_callback)
+    showPickerDialog(assistant, models, close_callback, nil, nil, context)
 end
 
 return showOpenRouterModelPicker

--- a/assistant_prompts.lua
+++ b/assistant_prompts.lua
@@ -253,6 +253,40 @@ Provide a concise, simple, and crystal-clear ELI5 explanation of the following, 
 
 {highlight}.]],
     },
+    companion = {
+        text = _("Book Companion"),
+        order = 70,
+        use_companion = true,            -- marks this a Book Companion prompt: injects the per-book
+                                         -- .companion.md and runs on the user-selected Book Companion provider.
+                                         -- Surfaced automatically for any book that has a sibling
+                                         -- <book>.companion.md sidecar (the file is the per-book linkage,
+                                         -- so no book_filter is needed and it survives restarts).
+        use_surrounding = true,          -- include the passage around the highlight (user message, not cached)
+        show_on_main_popup = true,       -- one-tap button in the highlight selection popup (when a companion file exists)
+        show_on_dictionary_popup = true, -- also appear in the single-word dictionary popup (when a companion file exists)
+        desc = _(
+            "Explains difficult passages of the current book using its pre-authored reference companion."),
+        system_prompt =
+        [[You are helping an intelligent, attentive reader understand a difficult passage from the book they are reading ("{title}" by {author}). Always respond in Markdown.
+
+A reference companion to this book may be provided in a separate system message. When it is, treat it as your PRIMARY, AUTHORITATIVE source for characters, plot, history, allusions, and terms.
+
+Rules:
+- Answer from the companion whenever possible.
+- If the passage needs something the companion does NOT cover, still help the reader using your own knowledge of this book and general knowledge — but clearly mark that portion by opening it with "⚠️ Beyond the companion:" so the reader knows it is not from the vetted reference.
+- If NO companion text is present at all, begin your reply with the single italic line "_(No companion loaded — answering from general knowledge.)_" and then help anyway.
+- Spoiler guard: respect the reader's current progress (given in the question). Use companion material only up to that point. Do NOT volunteer character fates or events from later in the book unless the reader explicitly asks.
+- Do NOT deliver generic commentary about irony, tone, or themes unless a SPECIFIC word or allusion in the passage genuinely requires it.
+- Short highlight = dictionary mode: if the highlighted passage is roughly three words or fewer, treat it primarily as a definition — lead with a concise explanation of what the word or phrase means (in the book's context where relevant), keep it brief, and skip the fuller comprehension structure below. Prefer the companion when it covers the term (glossary, allusions, character entries); otherwise define it from general knowledge, marked with the "⚠️ Beyond the companion:" note above.
+
+For longer highlights, focus on what is actually hard to follow: archaic or period vocabulary, historical and political context, biblical/classical/literary allusions, foreign-language phrases, and identifying who the named people are. Be concise; lead with the single most illuminating point. No plot summary, no praise.]],
+        user_prompt =
+        [[The reader is at {progress}% of the book.
+
+Help me understand this excerpt. Respond in {language}.
+
+{highlight}]],
+    },
     explain = {
         text = _("Explain"),
         order = 80,

--- a/assistant_provider_context.lua
+++ b/assistant_provider_context.lua
@@ -1,0 +1,160 @@
+-- Encapsulates "which provider/model selection are we editing" so the same
+-- settings + model-picker UI can drive either the global AI Provider or the
+-- Book Companion provider. Operates only on the injected `assistant` (its
+-- querier/settings/CONFIGURATION); requires NO KOReader modules, so it is
+-- unit-testable with fake tables (see tests/provider_context_spec.lua).
+
+local function getIn(t, ...)
+  local node = t
+  local keys = {...}
+  for i = 1, #keys do
+    if type(node) ~= "table" then return nil end
+    node = node[keys[i]]
+  end
+  return node
+end
+
+-- Handler name = part of the provider key before the first "_".
+-- "openai_o4mini" -> "openai"; "openrouter" -> "openrouter".
+local function handlerNameFor(provider_name)
+  if type(provider_name) ~= "string" then return nil end
+  local pos = provider_name:find("_")
+  if pos and pos > 1 then return provider_name:sub(1, pos - 1) end
+  return provider_name
+end
+
+local ProviderContext = {}
+ProviderContext.__index = ProviderContext
+
+function ProviderContext.main(assistant)
+  return setmetatable({
+    assistant = assistant,
+    settings = assistant.settings,
+    is_companion = false,
+    appliesToLiveQuerier = true,
+  }, ProviderContext)
+end
+
+function ProviderContext.bookCompanion(assistant)
+  return setmetatable({
+    assistant = assistant,
+    settings = assistant.settings,
+    is_companion = true,
+    appliesToLiveQuerier = false,
+  }, ProviderContext)
+end
+
+function ProviderContext:selectedProvider()
+  if self.is_companion then
+    local p = self.settings:readSetting("book_companion_provider")
+    if p == "" then return nil end
+    return p
+  end
+  return self.assistant.querier.provider_name
+end
+
+function ProviderContext:isSelected(key)
+  return key ~= nil and key == self:selectedProvider()
+end
+
+function ProviderContext:handlerNameFor(key)
+  return handlerNameFor(key)
+end
+
+function ProviderContext:baseUrlFor(key)
+  return getIn(self.assistant.CONFIGURATION, "provider_settings", key, "base_url")
+end
+
+-- Model to show "checked" in the picker for the selected provider.
+function ProviderContext:selectedModel()
+  local key = self:selectedProvider()
+  if not key then return nil end
+  if self.is_companion then
+    local m = self.settings:readSetting("book_companion_model_" .. key)
+    if m == "" then return nil end
+    return m
+  end
+  return getIn(self.assistant.querier, "provider_settings", "model")
+end
+
+-- Model string to show in a provider's radio label (per provider key).
+function ProviderContext:modelLabelFor(key)
+  local tab = getIn(self.assistant.CONFIGURATION, "provider_settings", key) or {}
+  if self.is_companion then
+    local m = self.settings:readSetting("book_companion_model_" .. key)
+    if m and m ~= "" then return m end
+    return getIn(tab, "model")
+  end
+  -- main: mirror the historical inline logic from SettingsDialog:init.
+  if key == self.assistant.querier.provider_name then
+    return getIn(self.assistant.querier, "provider_settings", "model")
+  elseif key:sub(1, 10) == "openrouter" then
+    local m = self.settings:readSetting("openrouter_model_" .. key)
+    if m == "" then
+      m = getIn(self.assistant.querier, "provider_settings", "model")
+    end
+    return m
+  end
+  return getIn(tab, "model") or getIn(tab, "deployment_name")
+end
+
+function ProviderContext:onSelect(key)
+  if self.is_companion then
+    self.settings:saveSetting("book_companion_provider", key)
+  else
+    self.settings:saveSetting("provider", key)
+  end
+  self.assistant.updated = true
+  if self.appliesToLiveQuerier then
+    self.assistant.querier:load_model(key)
+  end
+end
+
+-- Companion only: revert to "Not set" (companion prompts run on the main provider).
+function ProviderContext:clearSelection()
+  assert(self.is_companion, "clearSelection is companion-only")
+  self.settings:delSetting("book_companion_provider")
+  self.assistant.updated = true
+end
+
+function ProviderContext:saveModel(key, model_id)
+  if self.is_companion then
+    self.settings:saveSetting("book_companion_model_" .. key, model_id)
+  else
+    self.settings:saveSetting("openrouter_model_" .. key, model_id)
+    self.assistant.querier.provider_settings.model = model_id
+  end
+  self.assistant.updated = true
+end
+
+function ProviderContext:resetModel(key)
+  if self.is_companion then
+    self.settings:delSetting("book_companion_model_" .. key)
+  else
+    self.settings:delSetting("openrouter_model_" .. key)
+    self.assistant.querier.provider_settings.model =
+      getIn(self.assistant.CONFIGURATION, "provider_settings", key, "model")
+  end
+  self.assistant.updated = true
+end
+
+-- Pure: (provider, model) to run a prompt on, or (nil, nil) for "no override"
+-- (run on the current/main provider). Companion prompts follow the persisted
+-- Book Companion selection; all others keep their own `provider` field.
+function ProviderContext.resolveForPrompt(settings, prompt_config, configuration)
+  if prompt_config and prompt_config.use_companion then
+    local p = settings:readSetting("book_companion_provider")
+    if not p or p == "" then return nil, nil end
+    local m = settings:readSetting("book_companion_model_" .. p)
+    if not m or m == "" then
+      -- No companion model chosen: use the provider's config default so the
+      -- companion stays independent of the main provider's saved OpenRouter model.
+      m = getIn(configuration, "provider_settings", p, "model")
+    end
+    return p, m
+  end
+  local p = prompt_config and prompt_config.provider or nil
+  return p, nil
+end
+
+return ProviderContext

--- a/assistant_provider_override.lua
+++ b/assistant_provider_override.lua
@@ -1,0 +1,42 @@
+-- Temporarily switch the querier to another provider for one call, then restore.
+-- LuaJIT-compatible (no table.pack); forwards up to two return values, which is
+-- what Querier:query returns (answer, err).
+local M = {}
+
+function M.runWithProvider(querier, provider_name, model_override, run_fn)
+  if not provider_name then
+    return run_fn()
+  end
+
+  local saved = querier.provider_name
+  local saved_model = querier.provider_settings and querier.provider_settings.model
+  -- If the target provider is unconfigured, load_model may error; swallow it and
+  -- run on whatever provider is currently active rather than aborting the query.
+  pcall(function() querier:load_model(provider_name) end)
+
+  -- Only apply the model override if the target provider is actually active now
+  -- (load succeeded, or it was already the current provider). If load failed we
+  -- stay on the current provider and must NOT graft a foreign model onto it.
+  local switched = (querier.provider_name == provider_name)
+  if switched and model_override and querier.provider_settings then
+    querier.provider_settings.model = model_override
+  end
+
+  local ok, a, b = pcall(run_fn)
+
+  if saved ~= nil and saved ~= querier.provider_name then
+    -- Provider changed: reloading the saved provider rebuilds its own model too.
+    pcall(function() querier:load_model(saved) end)
+  elseif switched and model_override and querier.provider_settings then
+    -- Same provider, only the model was overridden: restore it explicitly.
+    querier.provider_settings.model = saved_model
+  end
+
+  if not ok then
+    -- Level 0: re-raise the value exactly as pcall captured it (no extra location prefix).
+    error(a, 0)
+  end
+  return a, b
+end
+
+return M

--- a/assistant_querier.lua
+++ b/assistant_querier.lua
@@ -159,7 +159,8 @@ end
 local function trimMessageHistory(message_history)
     local trimed_history = {}
     for i, message in ipairs(message_history) do
-        trimed_history[i] = { role = message.role, content = message.content, }
+        -- Preserve `cache` so Anthropic prompt-caching flags survive to the handler.
+        trimed_history[i] = { role = message.role, content = message.content, cache = message.cache, }
     end
     return trimed_history
 end

--- a/assistant_settings.lua
+++ b/assistant_settings.lua
@@ -32,6 +32,7 @@ local ffiutil = require("ffi/util")
 local meta = require("_meta")
 local logger = require("logger")
 local koutil = require("util")
+local ProviderContext = require("assistant_provider_context")
 
 -- Custom Widget: auto fill the empty field
 local MultiInputDialog = require("ui/widget/multiinputdialog")
@@ -179,6 +180,7 @@ local SettingsDialog = InputDialog:extend{
     assistant = nil, -- reference to the main assistant object
     CONFIGURATION = nil,
     settings = nil,
+    context = nil,
 
     -- widgets
     buttons = nil,
@@ -186,6 +188,8 @@ local SettingsDialog = InputDialog:extend{
 }
 
 function SettingsDialog:init()
+    self.context = self.context or ProviderContext.main(self.assistant)
+    self.title = self.context.is_companion and _("Book Companion Provider") or _("AI Provider Settings")
 
     self.title_bar_left_icon = "notice-info"
     self.title_bar_left_icon_tap_callback = function ()
@@ -196,11 +200,11 @@ function SettingsDialog:init()
     end
 
     -- action buttons
-    self.buttons = {{
+    local action_buttons = {
         {
             id = "select_model",
             text = _("Browse Models"),
-            enabled = self.assistant.querier.handler_name == "openrouter",
+            enabled = self.context:handlerNameFor(self.context:selectedProvider()) == "openrouter",
             callback = function() self:onSelectModel() end,
             hold_callback = function ()
                 UIManager:show(InfoMessage:new{
@@ -214,7 +218,15 @@ function SettingsDialog:init()
             text = _("Close"),
             callback = function() UIManager:close(self) end
         }
-    }}
+    }
+    if self.context.is_companion then
+        table.insert(action_buttons, 2, {
+            id = "reset_companion",
+            text = _("Use main provider"),
+            callback = function() self:onResetCompanion() end,
+        })
+    end
+    self.buttons = {action_buttons}
 
     -- init radio buttons for selecting AI Model provider
     self.radio_buttons = {} -- init radio buttons table
@@ -226,18 +238,7 @@ function SettingsDialog:init()
     for key, tab in ffiutil.orderedPairs(self.CONFIGURATION.provider_settings) do
         if not (FrontendUtil.tableGetValue(tab, "visible") == false) then -- skip `visible = false` providers
             if #buttonrow < columns then
-                local model_name
-                if key == self.assistant.querier.provider_name then
-                    model_name = self.assistant.querier.provider_settings.model
-                elseif key:sub(1, 10) == "openrouter" then
-                    model_name = self.settings:readSetting("openrouter_model_" .. key)
-                    if model_name == "" then
-                        model_name = self.assistant.querier.provider_settings.model
-                    end
-                else
-                    model_name = FrontendUtil.tableGetValue(tab, "model")
-                        or FrontendUtil.tableGetValue(tab, "deployment_name")
-                end
+                local model_name = self.context:modelLabelFor(key)
                 local button_text = key
                 if columns == 1 and model_name and model_name ~= "" then
                     button_text = string.format("%s (%s)", key, model_name)
@@ -246,7 +247,7 @@ function SettingsDialog:init()
                     text = button_text,
                     bold = (key:sub(1, 10) == "openrouter"),
                     provider = key, -- note: this `provider` field belongs to the RadioButton, not our AI Model provider.
-                    checked = (key == self.assistant.querier.provider_name),
+                    checked = self.context:isSelected(key),
                 })
             end
             if #buttonrow == columns then
@@ -277,9 +278,7 @@ function SettingsDialog:init()
         scroll = false,
         parent = self,
         button_select_callback = function(btn)
-            self.settings:saveSetting("provider", btn.provider)
-            self.assistant.updated = true
-            self.assistant.querier:load_model(btn.provider)
+            self.context:onSelect(btn.provider)
             self:updateSelectModelButton()
         end
     }
@@ -346,7 +345,7 @@ end
 function SettingsDialog:updateSelectModelButton()
     local btn = self.button_table:getButtonById("select_model")
     if btn then
-        if self.assistant.querier.handler_name == "openrouter" then
+        if self.context:handlerNameFor(self.context:selectedProvider()) == "openrouter" then
             btn:enable()
         else
             btn:disable()
@@ -358,14 +357,14 @@ end
 function SettingsDialog:onSelectModel()
     UIManager:close(self)
     local NetworkMgr = require("ui/network/manager")
-    local url = koutil.tableGetValue(self.assistant.querier, "provider_settings", "base_url")
-    if url ~= "" then
+    local url = self.context:baseUrlFor(self.context:selectedProvider())
+    if url and url ~= "" then
         url = url:gsub("/chat/.*$", "/models")
         NetworkMgr:runWhenOnline(function()
             local Trapper = require("ui/trapper")
             Trapper:wrap(function()
                 local showModelPicker = require("assistant_model_picker")
-                showModelPicker(self.assistant, self.close_callback, url)
+                showModelPicker(self.assistant, self.close_callback, url, self.context)
             end)
         end)
     else
@@ -376,12 +375,22 @@ function SettingsDialog:onSelectModel()
     end
 end
 
+function SettingsDialog:onResetCompanion()
+    -- UIManager:close triggers onCloseWidget, which fires close_callback (matches onSelectModel).
+    self.context:clearSelection()
+    UIManager:close(self)
+end
+
 function SettingsDialog:onCloseWidget()
     InputDialog.onCloseWidget(self)
     if self.close_callback then
         self.close_callback()
     end
-    self.assistant._settings_dialog = nil
+    if self.context and self.context.is_companion then
+        self.assistant._book_companion_dialog = nil
+    else
+        self.assistant._settings_dialog = nil
+    end
 end
 
 SettingsDialog.genMenuSettings = function (assistant)

--- a/companions/README.md
+++ b/companions/README.md
@@ -1,0 +1,9 @@
+# Generated Book Companions
+
+Each file here is a `<book-stem>.companion.md` reference companion produced by the
+`book-companion` skill (`.claude/skills/book-companion/`). The filename matches the
+source book's basename exactly, so the plugin's sidecar lookup
+(`assistant_companion.lua`) recognizes it verbatim when the file is placed beside the
+book on the device.
+
+These are original reference summaries, not reproductions of book text.

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -4,6 +4,12 @@ local CONFIGURATION = {
     -- NOTE: "openai" , "openai_grok" are different service using same handling code.
     provider = "openai",
 
+    -- Book companion files:
+    -- A prompt with `use_companion = true` (e.g. the "Middlemarch" button) looks for a
+    -- sidecar Markdown file next to the book: for "/Books/Middlemarch.epub" it loads
+    -- "/Books/Middlemarch.companion.md" if present, and injects it as authoritative
+    -- context (cached on Anthropic providers). Name the file to match the book's stem.
+
     -- Provider-specific settings
     --
     -- NAMING PATTERN: Configuration keys follow the format {handler}_{description}
@@ -66,6 +72,19 @@ local CONFIGURATION = {
                         max_uses = 5,
                     },
                 }
+            }
+        },
+        -- Anthropic Sonnet — one option selectable as the "Book Companion Provider"
+        -- in the AI Assistant menu. (No longer wired to any prompt by a `provider` field.)
+        -- The handler is determined by the part before the first underscore: "anthropic".
+        anthropic_sonnet = {
+            visible = false,                   -- optional, if set to false, will not shown in the profile switch
+            model = "claude-sonnet-4-6",       -- model list: https://docs.anthropic.com/en/docs/about-claude/models
+            base_url = "https://api.anthropic.com/v1/messages",
+            api_key = "your-anthropic-api-key",
+            additional_parameters = {
+                anthropic_version = "2023-06-01", -- api version list: https://docs.anthropic.com/en/api/versioning
+                max_tokens = 4096
             }
         },
         gemini = {
@@ -254,6 +273,7 @@ local CONFIGURATION = {
         updater_disabled = false,              -- Set to true to disable update check.
         default_folder_for_logs = nil,         -- Set the default folder for auto saved logs, nil for the same folder as the book, ex: "/mnt/onboard/logs/" for Kobo , "/mnt/us/documents/logs/" for Kindle
         max_text_length_for_analysis = 100000, -- max text length to be used on xray-recap-book analyzes,
+        -- surrounding_context_words = 90, -- words of context each side of the highlight for use_surrounding prompts
         max_page_size_for_analysis = 250,      -- maximum page size to be used on xray-recap-book analyzes (for page-based documents, ex: PDF)
 
         -- Term X-Ray context expansion settings (for analyzing characters, objects, places, concepts, magic)
@@ -318,6 +338,24 @@ local CONFIGURATION = {
         -- The `show_on_dictionary_popup` determines if the prompt is shown in the dictionary popup ( max 3 including the built-in ones)
         -- Set `visible = false` to hide the prompt from all popups.
         -- Available placeholders to use in the prompts: {user_input},{highlight},{title},{author},{language},{progress}
+        -- Book Companion prompts: set `use_companion = true`. The built-in `companion`
+        -- prompt ("Book Companion") works for any book; add more with keys like
+        -- `companion_<slug>` only if you want a book-specific system prompt. `use_companion`
+        -- is the behavioral marker (injects <book>.companion.md and uses the user's
+        -- "Book Companion Provider" choice); the key is identity only. Placeholders such
+        -- as {title} and {author} let one generic prompt serve every book.
+        -- Companion prompts are surfaced automatically for any book that has a sibling
+        -- <book>.companion.md sidecar -- the file's presence is the per-book linkage,
+        -- so they do NOT need (and ignore) book_filter, and the button persists across
+        -- restarts because it depends on the file rather than a saved menu toggle.
+        -- book_filter = { title_contains = "Middlemarch", author_contains = "Eliot" }
+        --   Restrict a NON-companion prompt's popup buttons to matching books (case-insensitive
+        --   substring of the book's title/authors). Prompts without a book_filter appear for all books.
+        -- use_surrounding = true
+        --   Prepend the passage around the highlight (ui.highlight:getSelectedWordContext) so the
+        --   model can resolve local references. Window: features.surrounding_context_words (default 90).
+        -- Note: to show prompts in the single-word dictionary popup, enable the
+        --   "show custom prompts in dictionary popup" setting (dict_popup_show_custom_prompts).
         prompts = {
 
             -- hide some prompts to keep the UI clean

--- a/docs/book-companion.md
+++ b/docs/book-companion.md
@@ -1,0 +1,104 @@
+# Book Companion
+
+A Book Companion is a pre-authored, comprehension-first reference that the assistant plugin loads alongside a specific book. It covers the cultural, historical, and linguistic knowledge a reader needs to understand the text — glossary terms, character identities, historical context, literary allusions, and untranslated phrases — without revealing anything about the story ahead.
+
+The design principle is comprehension over plot. A companion prioritizes what readers actually get stuck on: archaic or period vocabulary, political and historical background, classical and biblical allusions, foreign-language passages, and identifying who the named people are. Plot summary is kept to a minimum and is always chapter-anchored, so it can serve as a spoiler anchor rather than a plot guide. The companion is written for one specific book and verified against it at generation time.
+
+## What a Book Companion Is
+
+When you highlight a difficult passage in a book that has a companion, the plugin's "Book Companion" button appears in both the highlight popup and the dictionary popup. Tapping it sends the companion to the AI as its primary, authoritative reference and asks it to explain the passage using that reference first.
+
+The companion does not replace the AI's general knowledge — it focuses it. If the companion covers a term, the AI answers from it. If the companion does not cover something, the AI still helps, but labels that part clearly so you know it comes from general knowledge rather than the vetted reference. The AI is also spoiler-aware: it knows your current progress through the book and will not volunteer information from chapters you have not yet reached.
+
+For short highlights (roughly three words or fewer), the prompt switches to a concise dictionary mode — a brief definition of the word or phrase in context rather than a full comprehension explanation. For longer passages, it focuses on whatever is genuinely hard to follow: who someone is, what an allusion means, what a foreign phrase says, what the historical situation was.
+
+## The `.companion.md` Sidecar
+
+A companion is a plain Markdown file named `<book-stem>.companion.md`, placed in the same directory as the book file on the device.
+
+The filename stem is derived by stripping only the final extension from the book's path. For example:
+
+```
+/Books/Middlemarch.epub  →  /Books/Middlemarch.companion.md
+```
+
+The plugin (`assistant_companion.lua`) checks for this sibling file whenever you open a book. If the file exists and is non-empty, the companion prompt becomes available. If the file is missing, unreadable, or empty, the companion prompt is hidden — the plugin treats an empty file the same as an absent one.
+
+The name must match the book file's basename exactly. If your book is `The_Brothers_Karamazov.epub`, the companion must be `The_Brothers_Karamazov.companion.md`. The `companions/` folder in this repository stores the reference copies; to use a companion on a device, copy the `.companion.md` file from that folder to sit beside the book file.
+
+## The Companion Prompt and Sidecar-Gated Selector
+
+The "Book Companion" button is defined in `assistant_prompts.lua` with `use_companion = true`. This flag does two things: it causes the plugin to inject the sidecar's contents into the AI's context as a system message, and it routes the query through the Book Companion provider (if one is configured; see the next section).
+
+The button only appears when a non-empty companion sidecar exists for the currently open book. This check is done at the time the popup is drawn. There is no manual toggle — the file's presence is the switch.
+
+`show_on_main_popup = true` places the button directly in the highlight selection popup for one-tap access. `show_on_dictionary_popup = true` makes it available in the single-word dictionary popup as well.
+
+The AI's behavior when the companion is loaded:
+
+- **Companion-first**: The companion is treated as the primary, authoritative source for characters, plot, history, allusions, and terms.
+- **Beyond-the-companion marking**: If the passage requires something the companion does not cover, the AI still answers but opens that portion with `⚠️ Beyond the companion:` so you know it is not from the vetted reference.
+- **No companion fallback**: If the companion file could not be loaded (for example, the file disappeared after the popup was drawn), the AI begins with `_(No companion loaded — answering from general knowledge.)_` and then answers anyway.
+- **Spoiler guard**: The user prompt includes your current reading progress (`{progress}%`). The AI limits its use of companion material to what has already happened in the book and will not volunteer events or character fates from later chapters unless you explicitly ask.
+- **Short-highlight dictionary mode**: For passages of roughly three words or fewer, the AI leads with a concise definition rather than a full comprehension response. It prefers the companion's glossary, allusions, or character entries when the term appears there; otherwise it defines from general knowledge and marks it accordingly.
+
+## The Book Companion Provider
+
+The Book Companion uses a separate provider and model selection, independent of the plugin's global AI Provider. This lets you dedicate a specific model — for example, a context-heavy or literature-focused one — to companion queries without changing your main provider for other prompts.
+
+The selection is stored in the plugin's settings under the key `book_companion_provider`. Within that provider, a per-provider model override (`book_companion_model_<provider>`) is also stored separately from the main provider's model choice.
+
+To configure it, open the plugin's settings and look for the **Book Companion** provider section (distinct from the main AI Provider section). From there you can choose any provider and model that you have already configured in `configuration.lua`.
+
+If no Book Companion provider is set, companion prompts run on whatever provider is currently active for the rest of the plugin. Setting it to "Not set" reverts to that behavior. The provider override is applied only for queries routed through a `use_companion = true` prompt; all other prompts continue to use your main provider.
+
+## Generating a Companion
+
+Companions are produced by the `book-companion` Claude skill, which lives in `.claude/skills/book-companion/`. The skill orchestrates a four-stage pipeline of deterministic Python scripts (all stdlib, no installation required) and AI-authored comprehension writing.
+
+### The pipeline
+
+| Stage | Script | What it does |
+|-------|--------|--------------|
+| Resolve | `scripts/resolve_book.py` | Finds the book in Calibre and returns a source path |
+| Ingest | `scripts/ingest.py` | Normalizes the source to Markdown, detects chapter structure, emits `manifest.json` |
+| Harvest | `scripts/harvest_candidates.py` | Extracts foreign phrases, epigraphs, and recurring names as a coverage checklist |
+| Write | `scripts/write_companion.py` | Writes the finished companion to both the repo `companions/` folder and beside the book |
+| Verify | `scripts/verify_companion.py` | Checks the companion against the manifest (chapter coverage, filename, no stray prefix) |
+
+Writing the comprehension content — the glossary entries, allusion explanations, character identities, historical notes — is done by the AI during the skill run, guided by the candidates from the harvest stage and checked against the manifest by the verify script.
+
+### Running the generator
+
+Invoke the `book-companion` skill from a Claude Code session in this repository. Give it one of:
+
+- **A book title** — the skill resolves it via `calibredb` to an ePub or text file.
+- **An ePub path** — used directly.
+- **A `.md` or `.txt` path** — used directly.
+
+When resolving by title, the skill looks for the book in your Calibre library. The library location is determined in this order of precedence:
+
+1. The `--library` flag passed to `scripts/resolve_book.py`
+2. The `CALIBRE_LIBRARY` environment variable
+3. The default `~/Calibre Library`
+
+You do not need to set anything if your library is in the standard location.
+
+### What the pipeline produces
+
+After a successful run, the skill writes the companion to two places:
+
+1. `companions/<stem>.companion.md` in this repository — the reference copy for version control.
+2. `<book-folder>/<stem>.companion.md` beside the source book file — ready to deploy to a device.
+
+Deploying to the device is a separate manual step: copy the `.companion.md` file (from either location) to sit beside the book file on the device's storage, matching the naming rule described in [The `.companion.md` Sidecar](#the-companionmd-sidecar).
+
+### Verification
+
+After writing, the skill runs `scripts/verify_companion.py`. Three hard gates must pass for the result to be accepted:
+
+- No stray content before the first `#` heading in the companion file.
+- All chapters listed in the manifest appear in the companion.
+- The filename and output paths match what `write_companion.py` reported.
+
+The verify script also produces advisory lists — names and phrases from the harvest stage that are not clearly covered in the companion. These do not block acceptance but should be reviewed: a flagged name may be a hallucination or misspelling worth correcting, and a flagged phrase may indicate a genuine gap in the glossary.

--- a/main.lua
+++ b/main.lua
@@ -23,7 +23,10 @@ local N_ = _.ngettext
 local AssistantDialog = require("assistant_dialog")
 local UpdateChecker = require("assistant_update_checker")
 local Prompts = require("assistant_prompts")
+local BookFilter = require("assistant_book_filter")
+local Companion = require("assistant_companion")
 local SettingsDialog = require("assistant_settings")
+local ProviderContext = require("assistant_provider_context")
 local showDictionaryDialog = require("assistant_dictdialog")
 
 local Assistant = InputContainer:new {
@@ -296,6 +299,20 @@ function Assistant:addToMainMenu(menu_items)
                 end,
               },
               {
+                text_func = function ()
+                  local p = self.settings:readSetting("book_companion_provider")
+                  if not p or p == "" then return _("Book Companion Provider: Not set") end
+                  local m = self.settings:readSetting("book_companion_model_" .. p)
+                  return T(_("Book Companion Provider: %1(%2)"), p, m or _("default"))
+                end,
+                keep_menu_open = true,
+                callback = function (touchmenu_instance)
+                  self:showBookCompanionSettings(function ()
+                    touchmenu_instance:updateItems()
+                  end)
+                end,
+              },
+              {
                 text = _("AI Assistant Settings"),
                 sub_item_table_func = function ()
                   return SettingsDialog.genMenuSettings(self)
@@ -393,6 +410,20 @@ function Assistant:addToMainMenu(menu_items)
                     end,
                 },
                 {
+                    text_func = function ()
+                      local p = self.settings:readSetting("book_companion_provider")
+                      if not p or p == "" then return _("Book Companion Provider: Not set") end
+                      local m = self.settings:readSetting("book_companion_model_" .. p)
+                      return T(_("Book Companion Provider: %1(%2)"), p, m or _("default"))
+                    end,
+                    keep_menu_open = true,
+                    callback = function (touchmenu_instance)
+                      self:showBookCompanionSettings(function ()
+                        touchmenu_instance:updateItems()
+                      end)
+                    end,
+                },
+                {
                     text = _("AI Assistant Settings"),
                     sub_item_table_func = function ()
                       return SettingsDialog.genMenuSettings(self)
@@ -480,6 +511,26 @@ function Assistant:showSettings(close_callback)
 
   self._settings_dialog = settingDlg -- store reference to the dialog
   UIManager:show(settingDlg)
+end
+
+function Assistant:showBookCompanionSettings(close_callback)
+  if not self:isConfigured() then return end
+
+  if self._book_companion_dialog then
+    UIManager:show(self._book_companion_dialog)
+    return
+  end
+
+  local dlg = SettingsDialog:new{
+      assistant = self,
+      CONFIGURATION = CONFIGURATION,
+      settings = self.settings,
+      close_callback = close_callback,
+      context = ProviderContext.bookCompanion(self),
+  }
+
+  self._book_companion_dialog = dlg
+  UIManager:show(dlg)
 end
 
 function Assistant:getModelId()
@@ -687,8 +738,25 @@ function Assistant:init()
     end
 
     -- Add Custom buttons to main select popup menu
+    -- (already inside `if self.ui.document then`, so only getProps needs guarding)
+    local book_props = self.ui.document.getProps and self.ui.document:getProps() or {}
+    local has_companion = Companion.hasCompanion(self.ui.document.file)
     local showOnMain = Prompts.getSortedCustomPrompts(function (prompt, idx)
       if prompt.visible == false then
+        return false
+      end
+
+      -- Companion prompts surface whenever the current book has a sibling
+      -- <book>.companion.md sidecar. The file's presence is the per-book
+      -- linkage (instead of book_filter), so the button auto-appears and
+      -- persists across restarts by construction -- it depends on the file,
+      -- not a saved toggle or the book's (possibly missing) title metadata.
+      if prompt.use_companion then
+        return has_companion and prompt.show_on_main_popup == true
+      end
+
+      -- Book-scoped prompts only appear for matching books (nil filter matches all).
+      if not BookFilter.matches(prompt.book_filter, book_props) then
         return false
       end
 
@@ -861,16 +929,29 @@ function Assistant:_buildAssistantDictButtons(dict_popup_arg)
   end
 
   if self.settings:readSetting("dict_popup_show_custom_prompts", false) then
-    -- Collect custom prompts with show_on_dictionary_popup = true
+    -- Collect prompts (built-in + configured) flagged for the dictionary popup,
+    -- honoring per-prompt book_filter so book-scoped prompts only show for their book.
     local custom_prompts = {}
-    if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.prompts then
-      for prompt_key, prompt_config in pairs(CONFIGURATION.features.prompts) do
-        if prompt_config.show_on_dictionary_popup == true and prompt_config.visible ~= false then
-          table.insert(custom_prompts, {
-            id = prompt_key,
-            config = prompt_config
-          })
-        end
+    local book_props = (self.ui and self.ui.document and self.ui.document.getProps)
+      and self.ui.document:getProps() or {}
+    local book_filepath = self.ui and self.ui.document and self.ui.document.file
+    local has_companion = Companion.hasCompanion(book_filepath)
+    local merged = Prompts.getMergedCustomPrompts(FrontendUtil.tableGetValue(CONFIGURATION, "features", "prompts"))
+    for prompt_key, prompt_config in pairs(merged) do
+      -- Companion prompts are gated by the presence of the book's .companion.md
+      -- sidecar; other book-scoped prompts use book_filter.
+      local book_ok
+      if prompt_config.use_companion then
+        book_ok = has_companion
+      else
+        book_ok = BookFilter.matches(prompt_config.book_filter, book_props)
+      end
+      if prompt_config.show_on_dictionary_popup == true and prompt_config.visible ~= false
+         and book_ok then
+        table.insert(custom_prompts, {
+          id = prompt_key,
+          config = prompt_config
+        })
       end
     end
 

--- a/tests/anthropic_messages_spec.lua
+++ b/tests/anthropic_messages_spec.lua
@@ -1,0 +1,34 @@
+package.path = "./?.lua;" .. package.path
+local AM = require("api_handlers.anthropic_messages")
+
+local function eq(got, want, msg)
+  assert(got == want, (msg or "assert") .. " — expected [" .. tostring(want) .. "] got [" .. tostring(got) .. "]")
+end
+
+-- No cache flag: system is a concatenated string (back-compat), user messages preserved.
+local r1 = AM.prepare({
+  { role = "system", content = "A" },
+  { role = "system", content = "B" },
+  { role = "user",   content = "hi" },
+})
+eq(r1.system, "A\n\nB", "concat system")
+eq(#r1.messages, 1, "one message")
+eq(r1.messages[1].role, "user", "role")
+eq(r1.messages[1].content, "hi", "content")
+
+-- Cache flag present: system is an array of text blocks; only the flagged block carries cache_control.
+local r2 = AM.prepare({
+  { role = "system", content = "INSTR" },
+  { role = "system", content = "COMP", cache = true },
+  { role = "user",   content = "q" },
+})
+assert(type(r2.system) == "table", "system is array")
+eq(r2.system[1].type, "text", "block1 type")
+eq(r2.system[1].text, "INSTR", "block1 text")
+assert(r2.system[1].cache_control == nil, "block1 has no cache_control")
+eq(r2.system[2].text, "COMP", "block2 text")
+assert(r2.system[2].cache_control ~= nil, "block2 has cache_control")
+eq(r2.system[2].cache_control.type, "ephemeral", "block2 ephemeral")
+eq(#r2.messages, 1, "one message (cache case)")
+
+print("anthropic_messages_spec: OK")

--- a/tests/book_filter_spec.lua
+++ b/tests/book_filter_spec.lua
@@ -1,0 +1,23 @@
+package.path = "./?.lua;" .. package.path
+local BookFilter = require("assistant_book_filter")
+
+local function eq(got, want, msg)
+  assert(got == want, (msg or "assert") .. " — expected [" .. tostring(want) .. "] got [" .. tostring(got) .. "]")
+end
+
+local mm = { title = "Middlemarch - George Eliot", authors = "George Eliot" }
+
+eq(BookFilter.matches(nil, mm), true, "nil filter")
+eq(BookFilter.matches({ title_contains = "middlemarch" }, mm), true, "title ci match")
+eq(BookFilter.matches({ title_contains = "Bleak House" }, mm), false, "title no match")
+eq(BookFilter.matches({ author_contains = "eliot" }, mm), true, "author ci match")
+eq(BookFilter.matches({ author_contains = "Dickens" }, mm), false, "author no match")
+eq(BookFilter.matches({ title_contains = "Middlemarch", author_contains = "Eliot" }, mm), true, "both match")
+eq(BookFilter.matches({ title_contains = "Middlemarch", author_contains = "Dickens" }, mm), false, "one fails")
+eq(BookFilter.matches({ title_contains = "Middlemarch" }, nil), false, "nil props")
+eq(BookFilter.matches({ title_contains = "Middlemarch" }, {}), false, "empty props")
+eq(BookFilter.matches({}, mm), true, "empty filter table")
+-- non-string field → safe false, no crash
+eq(BookFilter.matches({ author_contains = "Eliot" }, { title = "X", authors = 42 }), false, "non-string field")
+
+print("book_filter_spec: OK")

--- a/tests/companion_spec.lua
+++ b/tests/companion_spec.lua
@@ -1,0 +1,49 @@
+package.path = "./?.lua;" .. package.path
+local Companion = require("assistant_companion")
+
+local function eq(got, want, msg)
+  assert(got == want, (msg or "assert") .. " — expected [" .. tostring(want) .. "] got [" .. tostring(got) .. "]")
+end
+
+-- standard epub
+eq(Companion.getCompanionPath("/Books/Middlemarch.epub"), "/Books/Middlemarch.companion.md", "epub")
+-- dotted filename: only the final extension is stripped
+eq(Companion.getCompanionPath("/Books/My.Book.epub"), "/Books/My.Book.companion.md", "dotted name")
+-- no extension: just append
+eq(Companion.getCompanionPath("/Books/README"), "/Books/README.companion.md", "no ext")
+-- dot in a directory but not in the filename: don't strip the dir dot
+eq(Companion.getCompanionPath("/a.d/Book"), "/a.d/Book.companion.md", "dir dot")
+-- nil / empty guard
+eq(Companion.getCompanionPath(nil), nil, "nil")
+eq(Companion.getCompanionPath(""), nil, "empty")
+
+-- loadCompanion: present file
+local base = "/tmp/koassist_test_book.epub"
+local comp = "/tmp/koassist_test_book.companion.md"
+local fh = io.open(comp, "w"); fh:write("HELLO COMPANION"); fh:close()
+eq(Companion.loadCompanion(base), "HELLO COMPANION", "load present")
+
+-- loadCompanion: empty file -> nil
+local fh2 = io.open(comp, "w"); fh2:write(""); fh2:close()
+eq(Companion.loadCompanion(base), nil, "load empty")
+os.remove(comp)
+
+-- loadCompanion: absent file -> nil (no throw)
+eq(Companion.loadCompanion(base), nil, "load absent")
+
+-- loadCompanion: nil path -> nil
+eq(Companion.loadCompanion(nil), nil, "load nil")
+
+-- hasCompanion: present non-empty -> true
+local fh3 = io.open(comp, "w"); fh3:write("X"); fh3:close()
+eq(Companion.hasCompanion(base), true, "has present")
+-- hasCompanion: empty file -> false (mirrors loadCompanion's empty == absent)
+local fh4 = io.open(comp, "w"); fh4:write(""); fh4:close()
+eq(Companion.hasCompanion(base), false, "has empty")
+os.remove(comp)
+-- hasCompanion: absent file -> false (no throw)
+eq(Companion.hasCompanion(base), false, "has absent")
+-- hasCompanion: nil path -> false
+eq(Companion.hasCompanion(nil), false, "has nil")
+
+print("companion_spec: OK")

--- a/tests/provider_context_spec.lua
+++ b/tests/provider_context_spec.lua
@@ -1,0 +1,167 @@
+package.path = "./?.lua;" .. package.path
+local PC = require("assistant_provider_context")
+
+local function eq(got, want, msg)
+  assert(got == want, (msg or "assert") .. " — expected [" .. tostring(want) .. "] got [" .. tostring(got) .. "]")
+end
+
+local function fakeSettings(init)
+  local store = {}
+  for k, v in pairs(init or {}) do store[k] = v end
+  return {
+    store = store,
+    readSetting = function(self, k) return self.store[k] end,
+    saveSetting = function(self, k, v) self.store[k] = v end,
+    delSetting = function(self, k) self.store[k] = nil end,
+  }
+end
+
+local function fakeAssistant(opts)
+  opts = opts or {}
+  local settings = opts.settings or fakeSettings(opts.init)
+  local load_calls = {}
+  return {
+    settings = settings,
+    CONFIGURATION = opts.CONFIGURATION or { provider_settings = {} },
+    querier = {
+      provider_name = opts.provider_name,
+      provider_settings = opts.provider_settings or {},
+      load_model = function(self, name) table.insert(load_calls, name); self.provider_name = name end,
+    },
+    load_calls = load_calls,
+    updated = nil,
+  }
+end
+
+-- 1. Companion: nothing selected by default.
+local a = fakeAssistant()
+local cc = PC.bookCompanion(a)
+eq(cc:selectedProvider(), nil, "companion default provider nil")
+eq(cc.is_companion, true, "is_companion true")
+eq(cc.appliesToLiveQuerier, false, "companion does not touch live querier")
+
+-- 2. Companion onSelect persists, does NOT call load_model.
+cc:onSelect("openrouter")
+eq(a.settings.store["book_companion_provider"], "openrouter", "companion provider persisted")
+eq(#a.load_calls, 0, "companion onSelect must not load_model")
+eq(a.updated, true, "updated flag set")
+eq(cc:selectedProvider(), "openrouter", "selectedProvider reflects persisted")
+
+-- 3. Companion saveModel uses per-provider key; switching providers has no stale carry-over.
+cc:saveModel("openrouter", "x-ai/grok:free")
+eq(a.settings.store["book_companion_model_openrouter"], "x-ai/grok:free", "model persisted per provider")
+eq(cc:selectedModel(), "x-ai/grok:free", "selectedModel for current provider")
+cc:onSelect("anthropic_sonnet")
+eq(cc:selectedModel(), nil, "no stale model after switching providers")
+
+-- 4. clearSelection reverts to nil.
+cc:clearSelection()
+eq(a.settings.store["book_companion_provider"], nil, "selection cleared")
+eq(cc:selectedProvider(), nil, "selectedProvider nil after clear")
+
+-- 5. resolveForPrompt.
+local s = fakeSettings({ book_companion_provider = "openrouter", book_companion_model_openrouter = "m1" })
+local p, m = PC.resolveForPrompt(s, { use_companion = true })
+eq(p, "openrouter", "resolve companion provider"); eq(m, "m1", "resolve companion model")
+local s2 = fakeSettings({})
+p, m = PC.resolveForPrompt(s2, { use_companion = true })
+eq(p, nil, "resolve nil when unset"); eq(m, nil, "resolve nil model when unset")
+p, m = PC.resolveForPrompt(s2, { provider = "openai_gpt" })
+eq(p, "openai_gpt", "non-companion keeps own provider"); eq(m, nil, "non-companion no model")
+
+-- 6. Main onSelect writes `provider` and loads the model live.
+local a2 = fakeAssistant({ provider_name = "haiku" })
+local mc = PC.main(a2)
+eq(mc.is_companion, false, "main not companion")
+eq(mc:selectedProvider(), "haiku", "main selectedProvider from querier")
+mc:onSelect("openrouter")
+eq(a2.settings.store["provider"], "openrouter", "main provider persisted")
+eq(a2.load_calls[1], "openrouter", "main onSelect loads model live")
+
+-- 7. Main saveModel writes openrouter_model_<key> and updates live model.
+mc:saveModel("openrouter", "modelZ")
+eq(a2.settings.store["openrouter_model_openrouter"], "modelZ", "main model key")
+eq(a2.querier.provider_settings.model, "modelZ", "main live model updated")
+
+-- 8. handlerNameFor derives prefix.
+eq(mc:handlerNameFor("openai_gpt4"), "openai", "handler prefix")
+eq(mc:handlerNameFor("openrouter"), "openrouter", "handler no underscore")
+
+-- 9. clearSelection is companion-only.
+local mc_err = PC.main(fakeAssistant({ provider_name = "haiku" }))
+local guard_ok = pcall(function() mc_err:clearSelection() end)
+eq(guard_ok, false, "main clearSelection must error")
+
+-- 10. resetModel companion path deletes book_companion_model_<provider>.
+local ra = fakeAssistant({ init = { book_companion_provider = "openrouter", book_companion_model_openrouter = "m" } })
+local rc = PC.bookCompanion(ra)
+rc:resetModel("openrouter")
+eq(ra.settings.store["book_companion_model_openrouter"], nil, "companion resetModel deletes per-provider key")
+
+-- 11. resetModel main path deletes openrouter_model_<provider> and reverts live model to config default.
+local ra2 = fakeAssistant({
+  provider_name = "openrouter",
+  provider_settings = { model = "override" },
+  init = { openrouter_model_openrouter = "override" },
+  CONFIGURATION = { provider_settings = { openrouter = { model = "config-default" } } },
+})
+local rc2 = PC.main(ra2)
+rc2:resetModel("openrouter")
+eq(ra2.settings.store["openrouter_model_openrouter"], nil, "main resetModel deletes model key")
+eq(ra2.querier.provider_settings.model, "config-default", "main resetModel reverts live model to config")
+
+-- 12. isSelected, baseUrlFor, and modelLabelFor basic checks.
+local la = fakeAssistant({
+  provider_name = "openrouter",
+  provider_settings = { model = "live-model" },
+  CONFIGURATION = { provider_settings = { openrouter = { base_url = "https://x/chat/completions", model = "cfg" } } },
+})
+local lc = PC.main(la)
+eq(lc:isSelected("openrouter"), true, "isSelected true for current")
+eq(lc:isSelected("other"), false, "isSelected false for other")
+eq(lc:baseUrlFor("openrouter"), "https://x/chat/completions", "baseUrlFor from CONFIGURATION")
+eq(lc:modelLabelFor("openrouter"), "live-model", "modelLabelFor current provider uses live model")
+
+-- 13. resolveForPrompt with nil prompt.
+do
+  local rp, rm = PC.resolveForPrompt(fakeSettings({}), nil)
+  eq(rp, nil, "resolveForPrompt nil prompt -> nil provider")
+  eq(rm, nil, "resolveForPrompt nil prompt -> nil model")
+end
+
+-- 14. resolveForPrompt: companion provider set, NO companion model -> falls back to CONFIGURATION default.
+do
+  local s = fakeSettings({ book_companion_provider = "openrouter" })
+  local cfg = { provider_settings = { openrouter = { model = "cfg-default" } } }
+  local rp, rm = PC.resolveForPrompt(s, { use_companion = true }, cfg)
+  eq(rp, "openrouter", "fallback: provider returned")
+  eq(rm, "cfg-default", "fallback: config-default model used when no companion model")
+end
+-- resolveForPrompt: companion model set -> wins over CONFIGURATION default.
+do
+  local s = fakeSettings({ book_companion_provider = "openrouter", book_companion_model_openrouter = "chosen" })
+  local cfg = { provider_settings = { openrouter = { model = "cfg-default" } } }
+  local rp, rm = PC.resolveForPrompt(s, { use_companion = true }, cfg)
+  eq(rm, "chosen", "explicit companion model wins over config default")
+end
+-- resolveForPrompt: companion provider set, no model, no config default -> nil model.
+do
+  local s = fakeSettings({ book_companion_provider = "anthropic_sonnet" })
+  local rp, rm = PC.resolveForPrompt(s, { use_companion = true }, { provider_settings = {} })
+  eq(rp, "anthropic_sonnet", "provider returned")
+  eq(rm, nil, "nil model when neither companion model nor config default present")
+end
+
+-- 15. modelLabelFor: a non-selected openrouter provider with no saved model -> nil (blank label), not the live model.
+do
+  local la = fakeAssistant({
+    provider_name = "openrouter_a",
+    provider_settings = { model = "live-a" },
+    CONFIGURATION = { provider_settings = { openrouter_b = { model = "cfg-b" } } },
+  })
+  local lc = PC.main(la)
+  -- openrouter_b is NOT the current provider and has no openrouter_model_openrouter_b saved.
+  eq(lc:modelLabelFor("openrouter_b"), nil, "unset openrouter model label is blank, not live model")
+end
+
+print("provider_context_spec: OK")

--- a/tests/provider_override_spec.lua
+++ b/tests/provider_override_spec.lua
@@ -1,0 +1,77 @@
+package.path = "./?.lua;" .. package.path
+local PO = require("assistant_provider_override")
+
+local function eq(got, want, msg)
+  assert(got == want, (msg or "assert") .. " — expected [" .. tostring(want) .. "] got [" .. tostring(got) .. "]")
+end
+
+-- Switch during run, restore after (different provider).
+local calls = {}
+local q = { provider_name = "haiku", provider_settings = { model = "haiku-model" } }
+function q:load_model(name)
+  table.insert(calls, name); self.provider_name = name
+  self.provider_settings = { model = name .. "-model" }  -- real load_model rebuilds settings
+  return true
+end
+local ans, err = PO.runWithProvider(q, "sonnet", nil, function()
+  eq(q.provider_name, "sonnet", "switched during run")
+  return "ANS", nil
+end)
+eq(ans, "ANS", "forwarded answer"); eq(err, nil, "forwarded nil err")
+eq(q.provider_name, "haiku", "restored after run")
+
+-- Model override applied during run, then restored (different provider).
+local q2 = { provider_name = "haiku", provider_settings = { model = "haiku-model" } }
+function q2:load_model(name)
+  self.provider_name = name; self.provider_settings = { model = name .. "-model" }; return true
+end
+PO.runWithProvider(q2, "sonnet", "claude-sonnet-4-6", function()
+  eq(q2.provider_name, "sonnet", "switched")
+  eq(q2.provider_settings.model, "claude-sonnet-4-6", "model overridden during run")
+  return "x"
+end)
+eq(q2.provider_name, "haiku", "provider restored")
+eq(q2.provider_settings.model, "haiku-model", "model restored after different-provider override")
+
+-- Model override on the SAME provider must not leak (load_model early-returns).
+local q3 = { provider_name = "openrouter", provider_settings = { model = "default-model" } }
+function q3:load_model(name)
+  -- same provider already active: early return, does NOT reset model.
+  if name == self.provider_name then return true end
+  self.provider_name = name; self.provider_settings = { model = name .. "-model" }; return true
+end
+PO.runWithProvider(q3, "openrouter", "free/model:free", function()
+  eq(q3.provider_settings.model, "free/model:free", "same-provider model overridden during run")
+  return "x"
+end)
+eq(q3.provider_name, "openrouter", "provider unchanged")
+eq(q3.provider_settings.model, "default-model", "same-provider model restored (no leak)")
+
+-- Nil provider: pass-through, no load_model.
+local q4calls = {}
+local q4 = { provider_name = "x", provider_settings = {} }
+function q4:load_model(n) table.insert(q4calls, n) end
+local a, b = PO.runWithProvider(q4, nil, nil, function() return 1, 2 end)
+eq(a, 1, "passthrough a"); eq(b, 2, "passthrough b"); eq(#q4calls, 0, "no load on nil provider")
+
+-- Error inside run_fn is re-raised; provider still restored.
+local q5 = { provider_name = "haiku", provider_settings = { model = "m" } }
+function q5:load_model(name) self.provider_name = name; self.provider_settings = { model = "m2" } end
+local ok = pcall(function()
+  PO.runWithProvider(q5, "sonnet", "z", function() error("boom") end)
+end)
+eq(ok, false, "error propagated")
+eq(q5.provider_name, "haiku", "provider restored after error")
+
+-- Unconfigured override (load_model leaves provider unchanged): no override applied, run on current.
+local q6 = { provider_name = "haiku", provider_settings = { model = "keep" } }
+function q6:load_model(name) error("unconfigured") end  -- swallowed by pcall in runWithProvider
+local ans6 = PO.runWithProvider(q6, "broken", "should-not-apply", function()
+  eq(q6.provider_name, "haiku", "stayed on current provider")
+  eq(q6.provider_settings.model, "keep", "model not overridden when load failed")
+  return "OK6"
+end)
+eq(ans6, "OK6", "ran on current provider")
+eq(q6.provider_settings.model, "keep", "model untouched after unconfigured override")
+
+print("provider_override_spec: OK")


### PR DESCRIPTION
# Introducing Book Companion

Classic books are classic for a reason. Middlemarch, Jane Eyre, all of those great 19th century classics are worth reading... but they're also hard to read. Were you ever stumped when trying to work your way through the Proust's dense prose, or something equally weighty? And wouldn't it be nice if AI could help?

I tried naively asking the Assistant AI when I came across questions in those books, and it was hit or miss. Not surprisingly, the problem was context.

What's cool is that because these books are all public domain, the model actually knows them. Plus, we can easily get DRM-free clean ePubs from sources like Standard Ebooks.

So my solution was to use AI to make something I call a "book companion". This is just a compressed "reader's guide" for a given book, with a list of characters, difficult terms in the text, and all sorts of context that can be helpful for AI.

Then I put this companion right next to the epub on disk (in KOReader). And when the plugin sees there's a companion, I now get a companion-specific book prompt when I highlight something. This prompt does two things:

1. It uses a dedicated model (using the same model selection box we already have, but just for this feature). This way I can choose a smarter or more expensive/appropriate model just for these queries which tend to be harder.
2. It then pings this model with a query, putting the companion text as part of the query itself.

And now, what do you know, I get spot-on answers from AI on the specific books I'm reading. I can highlight the most cryptic and obscure bit of British horseriding jargon from the 1830s and get back a sensible reply in context. So nice.

## What's in here

This PR has a couple of different things:

1. The plugin changes for the companion prompt, model selection dialog etc.
2. AI tooling for making these companions. It can even plug into your Calibre library using Calibredb so you can just say "Use the skill for making companions and make me a companion text for Jane Eyre" and it'll just do the whole thing for you, assuming you have Jane Eyre in your library.

Maybe the companion-creation tooling doesn't belong here, but OTOH the whole feature isn't very useful without one of these companion texts, so it felt partial/wrong to try and contribute it without and send people chasing through github, looking for a way to make these texts.
