### PR TITLE
feat(openai): whitelist enable_thinking and thinking_budget options

### DIFF
--- a/api_handlers/openai.lua
+++ b/api_handlers/openai.lua
@@ -13,6 +13,8 @@ OpenAIHandler.SupportedOptions = {
     ["reasoning_effort"] = true,
     ["reasoning_format"] = true,
     ["search_settings" ] = true,
+    ["enable_thinking"] = true,
+    ["thinking_budget"] = true,
 }
 
 function OpenAIHandler:SetHandlerOption(querier)

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -236,6 +236,20 @@ local CONFIGURATION = {
                 reasoning_effort = "none"
             }
         },
+        openai_modelstudio = {
+            -- Alibaba Cloud Model Studio (Qwen) via OpenAI-compatible endpoint
+            model = "qwen3.6-flash",
+            base_url = "https://{WorkspaceId}.{Region}.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+            api_key = "your-modelstudio-api-key",
+            additional_parameters = {
+                temperature = 0.7,
+                max_tokens = 4096,
+                -- Set to false to disable reasoning/thinking for low latency
+                enable_thinking = false,
+                -- Alternatively, if enable_thinking is true, set a budget for thinking tokens (e.g. 512 or 1024)
+                -- thinking_budget = 1024,
+            }
+        },
         openai_azure = {
             endpoint = "https://your-resource-name.openai.azure.com/your-deployment-name/chat/completions?api-version=2024-02-15-preview", -- Your Azure OpenAI resource endpoint
             deployment_name = "your-deployment-name",                 -- Your model deployment name


### PR DESCRIPTION
Adds support for two Alibaba Model Studio specific options for the OpenAI provider to control thinking. Without these parameters, Qwen models provided by the OpenAI compatible endpoint of Alibaba Model Studio will default to excessive levels of thinking, unsuitable for this use case.

This is the minimalist, dirty hack workaround, however might be confusing since these parameters seem specific to this implementation. 
- A less hacky alternative is to create a separate provider based on OpenAI that has a different set of supported options. 
- Second alternative is to support their native DashScope API, but that may be too much maintenance burden for little benefit as it is not supported in several regions anyways.