### PR TITLE
Fix oversized hollow markdown list bullets in the response viewer

### DIFF
--- a/assistant_viewer.lua
+++ b/assistant_viewer.lua
@@ -85,16 +85,28 @@ ol, ul, menu {
     padding-left: 1.5em;
 }
 
+/* Use a small filled disc at every nesting level.
+   This viewer renders through MuPDF (ScrollHtmlWidget), whose built-in
+   stylesheet assigns list markers by depth (level 2 = hollow "circle",
+   level 3 = "square") and draws the hollow "circle" noticeably larger than
+   the text -- an oversized bullet. MuPDF applies these per-depth markers in a
+   way a plain author rule does not override, so !important is required. It
+   also does not support ::before/generated content, so a native
+   list-style-type is the only option. */
 ul {
-    list-style-type: circle;
+    list-style-type: disc;
 }
 
 ul ul {
-    list-style-type: square;
+    list-style-type: disc !important;
 }
 
 ul ul ul {
-    list-style-type: disc;
+    list-style-type: disc !important;
+}
+
+li {
+    list-style-type: disc !important;
 }
 
 ul li a {


### PR DESCRIPTION
## Problem

Bulleted lists in AI responses render with an oversized **hollow circle** as the top-level marker. It looks out of place and is visibly larger than the surrounding text.

## Cause

The response viewer (`ChatGPTViewer`) renders Markdown-as-HTML through **MuPDF** (`ScrollHtmlWidget` → `HtmlBoxWidget`), not crengine. The current `VIEWER_CSS` sets:

```css
ul     { list-style-type: circle; }
ul ul  { list-style-type: square; }
ul ul ul { list-style-type: disc; }
```

Under MuPDF, `list-style-type: circle` (a hollow ring) is drawn noticeably larger than `disc`, so the default top-level bullet shows up as a big empty circle.

## Fix

Use a small filled `disc` at every nesting level.

Two MuPDF-specific details drive the exact rules used:

- MuPDF assigns list markers **by nesting depth** in its built-in stylesheet, and a plain author rule does **not** override the nested levels — so `!important` is required on the nested selectors (and on `li`).
- MuPDF does **not** support `::before` / generated content, so scaling a custom bullet glyph isn't an option; a native `list-style-type` is the only lever.

```css
ul       { list-style-type: disc; }
ul ul    { list-style-type: disc !important; }
ul ul ul { list-style-type: disc !important; }
li       { list-style-type: disc !important; }
```

## Testing

Rendered the exact CSS through `ScrollHtmlWidget` (the same MuPDF path the plugin uses) on an Onyx Boox device running KOReader v2026.03, with a 3-level nested list. All levels show a consistent small filled dot; nested levels no longer fall back to the oversized hollow circle / square.
