### PR TITLE
fix: forward thinking parameter to OpenAI-compatible handlers

### DIFF
--- a/api_handlers/openai.lua
+++ b/api_handlers/openai.lua
@@ -22,6 +22,7 @@ OpenAIHandler.SupportedOptions = {
     ["reasoning_format"] = true,
     ["reasoning_effort"] = true,
     ["reasoning"] = true,
+    ["thinking"] = true,
     ["thinking_budget"] = true,
     ["enable_thinking"] = true,
 }


### PR DESCRIPTION
## Problem

The DeepSeek handler aliases `OpenAIHandler`, whose `buildRequestBody` filters `additional_parameters` through the `SupportedOptions` whitelist. The `thinking` key was missing from that list, so `thinking = { type = "disabled" }` (and the `enabled`/`budget_tokens` variants) documented in `configuration.sample.lua` were silently dropped before the request reached the DeepSeek API.

This is a regression from the `add websearch tool calling (#180)` refactor, which replaced DeepSeek's custom `query()` (which forwarded `thinking`) with a thin alias to `OpenAIHandler`.

## Fix

Add `["thinking"] = true` to `OpenAIHandler.SupportedOptions` in `api_handlers/openai.lua`, so the parameter is forwarded whenever a provider's `additional_parameters` sets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)