### PR TITLE
Add multiple general notebooks

### DIFF
--- a/assistant_dialog.lua
+++ b/assistant_dialog.lua
@@ -19,6 +19,7 @@ local Device = require("device")
 local Screen = Device.screen
 local CheckButton = require("ui/widget/checkbutton")
 local ASUtils = require("assistant_utils")
+local Notebook = require("assistant_notebook")
 local extractBookTextForAnalysis = ASUtils.extractBookTextForAnalysis
 local normalizeMarkdownHeadings = ASUtils.normalizeMarkdownHeadings
 local NetworkMgr = require("ui/network/manager")
@@ -317,6 +318,8 @@ function AssistantDialog:show(highlightedText)
 
   -- Handle regular dialog (user input prompt, other buttons)
   local book = self:_getBookContext()
+  local use_multi_general_notebooks =
+      not self.assistant.ui.doc_settings and Notebook.isEnabled(self.assistant)
   local system_prompt = koutil.tableGetValue(self.CONFIGURATION, "features", "system_prompt") or koutil.tableGetValue(Prompts, "assistant_prompts", "default", "system_prompt")
   if self.assistant.settings:readSetting("auto_prompt_suggest", false) then
     local language = self.assistant.settings:readSetting("response_language") or self.assistant.ui_language
@@ -340,7 +343,48 @@ function AssistantDialog:show(highlightedText)
         self:_close()
       end
     },
-    {
+  }
+
+  if use_multi_general_notebooks then
+    table.insert(first_row, {
+      id = "general_notebook",
+      text = Notebook.getActiveDisplayName(self.assistant, 18),
+      callback = function()
+        -- Hide the keyboard while the picker is open, but keep the current
+        -- question text in the existing InputDialog.
+        if self.input_dialog then
+          self.input_dialog:onCloseKeyboard()
+        end
+
+        Notebook.showPicker(self.assistant, {
+          title = _("Select notebook"),
+          on_select = function()
+            if not self.input_dialog then
+              return
+            end
+
+            local button = self.input_dialog.button_table
+                and self.input_dialog.button_table:getButtonById("general_notebook")
+            if button then
+              button:setText(
+                Notebook.getActiveDisplayName(self.assistant, 18),
+                button.width
+              )
+              button:refresh()
+            end
+
+            UIManager:nextTick(function()
+              if self.input_dialog then
+                self.input_dialog:onShowKeyboard()
+              end
+            end)
+          end,
+        })
+      end,
+    })
+  end
+
+  table.insert(first_row, {
       text = _("Ask"),
       is_enter_default = true,
       callback = function()
@@ -384,9 +428,8 @@ function AssistantDialog:show(highlightedText)
           self:_createAndShowViewer(highlightedText, message_history, viewer_title)
         end)
       end
-    }
-  }
-  
+    })
+
   -- Only add additional buttons if there's highlighted text
   if is_highlighted then
     local sorted_prompts = Prompts.getSortedPrompts(function (prompt)

--- a/assistant_notebook.lua
+++ b/assistant_notebook.lua
@@ -1,0 +1,488 @@
+local T = require("ffi/util").template
+local lfs = require("libs/libkoreader-lfs")
+local util = require("util")
+local UIManager = require("ui/uimanager")
+local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
+local Menu = require("ui/widget/menu")
+local _ = require("assistant_gettext")
+
+local M = {}
+
+local GENERAL_NOTEBOOKS_DIR = "general_notebooks"
+local LEGACY_NOTEBOOK_FILENAME = "general_notebook.md"
+local ACTIVE_NOTEBOOK_SETTING = "active_general_notebook"
+local MULTI_NOTEBOOK_SETTING = "use_multiple_general_notebooks"
+
+local function joinPath(parent, child)
+    if not parent or parent == "" then
+        return nil
+    end
+    if parent:sub(-1) == "/" then
+        return parent .. child
+    end
+    return parent .. "/" .. child
+end
+
+local function getFeature(assistant, key)
+    if not assistant or type(assistant.CONFIGURATION) ~= "table" then
+        return nil
+    end
+    return util.tableGetValue(assistant.CONFIGURATION, "features", key)
+end
+
+local function getCurrentBaseDirectory(assistant)
+    local default_folder = getFeature(assistant, "default_folder_for_logs")
+    if default_folder and default_folder ~= ""
+        and lfs.attributes(default_folder, "mode") == "directory" then
+        return default_folder
+    end
+
+    local home_dir = G_reader_settings:readSetting("home_dir")
+    if home_dir and home_dir ~= ""
+        and lfs.attributes(home_dir, "mode") == "directory" then
+        return home_dir
+    end
+
+    if assistant and assistant.ui then
+        if assistant.ui.file_chooser and assistant.ui.file_chooser.path then
+            return assistant.ui.file_chooser.path
+        end
+        if assistant.ui.getLastDirFile then
+            return assistant.ui:getLastDirFile()
+        end
+    end
+
+    return nil
+end
+
+local function getMode(path)
+    if not path then
+        return nil
+    end
+    return lfs.attributes(path, "mode")
+end
+
+local function isDirectory(path)
+    return getMode(path) == "directory"
+end
+
+local function isFile(path)
+    return getMode(path) == "file"
+end
+
+local function displayName(filename)
+    return filename:gsub("%.[mM][dD]$", "")
+end
+
+local function makeEntry(path, filename, legacy)
+    local attr = lfs.attributes(path)
+    return {
+        name = displayName(filename),
+        filename = filename,
+        path = path,
+        mtime = attr and attr.modification or 0,
+        legacy = legacy == true,
+    }
+end
+
+local function validateStoredFilename(filename)
+    if type(filename) ~= "string" or filename == "" then
+        return false
+    end
+    if filename:find("[/\\]") or filename:find("..", 1, true) then
+        return false
+    end
+    return filename:lower():sub(-3) == ".md"
+end
+
+function M.isEnabled(assistant)
+    return assistant
+        and assistant.settings
+        and assistant.settings:readSetting(MULTI_NOTEBOOK_SETTING, false)
+        or false
+end
+
+function M.getLegacyPath(assistant)
+    local target_dir = getCurrentBaseDirectory(assistant)
+    return target_dir and joinPath(target_dir, LEGACY_NOTEBOOK_FILENAME) or nil
+end
+
+-- Returns: folder, error, warning.
+-- A configured general_notebooks_folder must already exist. If it does not,
+-- the default general_notebooks subfolder is used instead and a warning is returned.
+function M.getFolder(assistant, for_write)
+    local configured_folder = getFeature(assistant, "general_notebooks_folder")
+    local warning
+
+    if configured_folder and configured_folder ~= "" then
+        if isDirectory(configured_folder) then
+            return configured_folder, nil, nil
+        end
+        warning = T(_("Configured general notebooks folder is not accessible: %1"), configured_folder)
+    end
+
+    local base_dir = getCurrentBaseDirectory(assistant)
+    if not base_dir then
+        return nil, _("No base folder is available for general notebooks."), warning
+    end
+
+    local folder = joinPath(base_dir, GENERAL_NOTEBOOKS_DIR)
+    local mode = getMode(folder)
+    if mode == "directory" then
+        return folder, nil, warning
+    end
+    if mode ~= nil then
+        return nil, T(_("General notebooks path is not a directory: %1"), folder), warning
+    end
+
+    if not for_write then
+        return folder, nil, warning
+    end
+
+    local ok, err = lfs.mkdir(folder)
+    if not ok and not isDirectory(folder) then
+        return nil, T(_("Could not create general notebooks folder: %1"), tostring(err)), warning
+    end
+
+    return folder, nil, warning
+end
+
+-- Returns: notebooks, error, warning.
+function M.list(assistant)
+    local notebooks = {}
+    local legacy_path = M.getLegacyPath(assistant)
+    local legacy_entry
+
+    if legacy_path and isFile(legacy_path) then
+        legacy_entry = makeEntry(legacy_path, LEGACY_NOTEBOOK_FILENAME, true)
+    end
+
+    local folder, err, warning = M.getFolder(assistant, false)
+    if folder and isDirectory(folder) then
+        local ok, iter, dir_obj = pcall(lfs.dir, folder)
+        if ok and iter then
+            for filename in iter, dir_obj do
+                if filename ~= "." and filename ~= ".." and filename:lower():sub(-3) == ".md" then
+                    local path = joinPath(folder, filename)
+                    if path ~= legacy_path and isFile(path) then
+                        notebooks[#notebooks + 1] = makeEntry(path, filename, false)
+                    end
+                end
+            end
+        elseif not err then
+            err = T(_("Could not list general notebooks folder: %1"), folder)
+        end
+    end
+
+    table.sort(notebooks, function(a, b)
+        if a.mtime == b.mtime then
+            return a.name:lower() < b.name:lower()
+        end
+        return a.mtime > b.mtime
+    end)
+
+    if legacy_entry then
+        table.insert(notebooks, 1, legacy_entry)
+    end
+
+    return notebooks, err, warning
+end
+
+-- Returns: notebook, error, warning.
+function M.getActive(assistant)
+    local filename = assistant
+        and assistant.settings
+        and assistant.settings:readSetting(ACTIVE_NOTEBOOK_SETTING)
+        or nil
+
+    local folder_err
+    local folder_warning
+    if filename and validateStoredFilename(filename) then
+        local folder
+        folder, folder_err, folder_warning = M.getFolder(assistant, false)
+        if folder then
+            local path = joinPath(folder, filename)
+            if isFile(path) then
+                return makeEntry(path, filename, false), nil, folder_warning
+            end
+        end
+    end
+
+    -- Do not clear a missing active notebook here. A configured or synced folder
+    -- may be temporarily unavailable; falling back must not destroy the sticky choice.
+    local legacy_path = M.getLegacyPath(assistant)
+    if not legacy_path then
+        return nil, folder_err or _("No path is available for the legacy general notebook."), folder_warning
+    end
+    return makeEntry(legacy_path, LEGACY_NOTEBOOK_FILENAME, true), folder_err, folder_warning
+end
+
+function M.setActive(assistant, notebook)
+    if not assistant or not assistant.settings then
+        return nil, _("Assistant settings are not available.")
+    end
+    if type(notebook) ~= "table" then
+        return nil, _("Invalid notebook entry.")
+    end
+
+    if notebook.legacy then
+        assistant.settings:delSetting(ACTIVE_NOTEBOOK_SETTING)
+        assistant.updated = true
+        return true
+    end
+
+    if not validateStoredFilename(notebook.filename) then
+        return nil, _("Invalid notebook filename.")
+    end
+
+    assistant.settings:saveSetting(ACTIVE_NOTEBOOK_SETTING, notebook.filename)
+    assistant.updated = true
+    return true
+end
+
+local function isReservedFilenameStem(stem)
+    local upper = stem:upper()
+    return upper == "CON"
+        or upper == "PRN"
+        or upper == "AUX"
+        or upper == "NUL"
+        or upper:match("^COM[1-9]$") ~= nil
+        or upper:match("^LPT[1-9]$") ~= nil
+end
+
+-- Returns a normalized Markdown filename or nil plus an error.
+function M.normalizeName(name)
+    if type(name) ~= "string" then
+        return nil, _("Notebook name must be text.")
+    end
+
+    name = name:gsub("^%s+", ""):gsub("%s+$", "")
+    if name == "" or name == "." or name == ".." then
+        return nil, _("Notebook name cannot be empty.")
+    end
+    if name:find("[/\\]") then
+        return nil, _("Notebook name cannot contain path separators.")
+    end
+    if name:find("..", 1, true) then
+        return nil, _("Notebook name cannot contain '..'.")
+    end
+    if name:find('[<>:"|%?%*]') or name:find("[%z\1-\31]") then
+        return nil, _("Notebook name contains characters that are not supported by the filesystem.")
+    end
+    if name:match("[%.%s]$") and name:lower():sub(-3) ~= ".md" then
+        return nil, _("Notebook name cannot end with a space or dot.")
+    end
+
+    if name:lower():sub(-3) == ".md" then
+        name = name:sub(1, -4) .. ".md"
+    else
+        name = name .. ".md"
+    end
+
+    local stem = name:sub(1, -4)
+    if stem == "" then
+        return nil, _("Notebook name cannot be empty.")
+    end
+
+    -- FAT/Windows reserved device names remain reserved even when followed
+    -- by another extension, e.g. CON.txt or COM1.notes.
+    local device_name = stem:match("^([^%.]+)") or stem
+    if isReservedFilenameStem(device_name) then
+        return nil, _("Notebook name is reserved by the filesystem.")
+    end
+
+    return name
+end
+
+-- Returns: notebook, error, warning.
+function M.create(assistant, name)
+    local filename, name_err = M.normalizeName(name)
+    if not filename then
+        return nil, name_err, nil
+    end
+
+    local folder, folder_err, warning = M.getFolder(assistant, true)
+    if not folder then
+        return nil, folder_err, warning
+    end
+
+    local path = joinPath(folder, filename)
+    local mode = getMode(path)
+    if mode and mode ~= "file" then
+        return nil, T(_("Notebook path is not a file: %1"), path), warning
+    end
+
+    if not mode then
+        local file, open_err = io.open(path, "a")
+        if not file then
+            return nil, T(_("Could not create notebook: %1"), tostring(open_err)), warning
+        end
+        file:close()
+    end
+
+    local notebook = makeEntry(path, filename, false)
+    local ok, setting_err = M.setActive(assistant, notebook)
+    if not ok then
+        return nil, setting_err, warning
+    end
+
+    return notebook, nil, warning
+end
+
+
+local function showMessage(text, is_warning)
+    if not text or text == "" then
+        return
+    end
+    UIManager:show(InfoMessage:new{
+        icon = is_warning and "notice-warning" or nil,
+        text = text,
+        timeout = 5,
+    })
+end
+
+function M.getActiveDisplayName(assistant, max_chars)
+    local notebook = M.getActive(assistant)
+    local name = notebook and notebook.name or displayName(LEGACY_NOTEBOOK_FILENAME)
+
+    if max_chars and max_chars > 1 then
+        local chars = util.splitToChars(name)
+        if #chars > max_chars then
+            return table.concat(chars, "", 1, max_chars - 1) .. "…"
+        end
+    end
+
+    return name
+end
+
+function M.showCreateDialog(assistant, options)
+    options = options or {}
+
+    local dialog
+    dialog = InputDialog:new{
+        title = _("New notebook"),
+        input_hint = _("Notebook name"),
+        description = _("Create a general notebook."),
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(dialog)
+                    end,
+                },
+                {
+                    text = _("Create"),
+                    is_enter_default = true,
+                    callback = function()
+                        local notebook, err, warning = M.create(
+                            assistant,
+                            dialog:getInputText()
+                        )
+
+                        if warning then
+                            showMessage(warning, true)
+                        end
+
+                        if not notebook then
+                            showMessage(err or _("Could not create notebook."), true)
+                            return
+                        end
+
+                        UIManager:close(dialog)
+                        if options.parent then
+                            UIManager:close(options.parent)
+                        end
+                        if options.on_select then
+                            options.on_select(notebook)
+                        end
+                    end,
+                },
+            },
+        },
+    }
+
+    UIManager:show(dialog)
+    dialog:onShowKeyboard()
+    return dialog
+end
+
+function M.showPicker(assistant, options)
+    options = options or {}
+
+    local notebooks, err, warning = M.list(assistant)
+    if warning then
+        showMessage(warning, true)
+    end
+    if err then
+        showMessage(err, true)
+    end
+
+    local active = M.getActive(assistant)
+    local menu
+    local items = {}
+    local active_index
+
+    for _, notebook in ipairs(notebooks) do
+        local is_active = active
+            and notebook.path
+            and active.path == notebook.path
+
+        if is_active then
+            active_index = #items + 1
+        end
+
+        items[#items + 1] = {
+            text = (is_active and "✓ " or "") .. notebook.name,
+            callback = function()
+                local ok, set_err = M.setActive(assistant, notebook)
+                if not ok then
+                    showMessage(set_err or _("Could not select notebook."), true)
+                    return
+                end
+
+                UIManager:close(menu)
+                if options.on_select then
+                    options.on_select(notebook)
+                end
+            end,
+        }
+    end
+
+    if #items == 0 then
+        items[#items + 1] = {
+            text = _("No general notebooks yet"),
+            enabled = false,
+        }
+    end
+
+    items[#items + 1] = {
+        text = _("New notebook…"),
+        callback = function()
+            M.showCreateDialog(assistant, {
+                parent = menu,
+                on_select = options.on_select,
+            })
+        end,
+    }
+
+    if active_index then
+        items.current = active_index
+    end
+
+    menu = Menu:new{
+        title = options.title or _("General notebooks"),
+        subtitle = T(
+            _("Active: %1"),
+            M.getActiveDisplayName(assistant, 24)
+        ),
+        item_table = items,
+    }
+
+    UIManager:show(menu)
+    return menu
+end
+
+return M

--- a/assistant_quicknote.lua
+++ b/assistant_quicknote.lua
@@ -10,6 +10,7 @@ local T = require("ffi/util").template
 local util = require("util")
 local _ = require("assistant_gettext")
 local ASUtils = require("assistant_utils")
+local Notebook = require("assistant_notebook")
 
 local QuickNote = {}
 
@@ -23,8 +24,17 @@ function QuickNote:new(assistant)
 end
 
 function QuickNote:createNoteInputDialog(callback, highlighted_text)
+  local description = nil
+  if not self.assistant.ui.doc_settings and Notebook.isEnabled(self.assistant) then
+    description = T(
+      _("Notebook: %1"),
+      Notebook.getActiveDisplayName(self.assistant, 24)
+    )
+  end
+
   self.input_dialog = InputDialog:new {
     title = _("Take Quick Notes"),
+    description = description,
     input = "",
     input_hint = _("Write quick notes here"),
     input_type = "text",
@@ -116,12 +126,28 @@ function QuickNote:saveNote(note_text, highlighted_text)
     log_entry = string.format("# [%s]\n## %s\n\n### ⮞ %s \n\n%s\n\n", timestamp, quick_note_lbl, user_lbl, processed_note)
   end
 
-  ASUtils.saveToNotebookFile(self.assistant, log_entry)
+  local saved_path, _save_err, used_fallback = ASUtils.saveToNotebookFile(self.assistant, log_entry)
+  if not saved_path then
+    return
+  end
 
-  UIManager:show(InfoMessage:new{
-    text = _("Quick note saved successfully"),
-    timeout = 2
-  })
+  if not self.assistant.ui.doc_settings
+      and Notebook.isEnabled(self.assistant)
+      and not used_fallback then
+    local saved_name = saved_path:match("([^/\\]+)$") or saved_path
+    saved_name = saved_name:gsub("%.md$", "")
+    UIManager:show(InfoMessage:new{
+      text = T(_("Saved to: %1"), saved_name),
+      timeout = 2
+    })
+  elseif not self.assistant.ui.doc_settings and Notebook.isEnabled(self.assistant) then
+    return
+  else
+    UIManager:show(InfoMessage:new{
+      text = _("Quick note saved successfully"),
+      timeout = 2
+    })
+  end
 end
 
 return QuickNote

--- a/assistant_settings.lua
+++ b/assistant_settings.lua
@@ -584,6 +584,16 @@ SettingsDialog.genMenuSettings = function(assistant)
             end
         },
         {
+            text = _("Use multiple general notebooks"),
+            checked_func = function ()
+                return assistant.settings:readSetting("use_multiple_general_notebooks", false)
+            end,
+            callback = function()
+                assistant.settings:toggle("use_multiple_general_notebooks")
+                assistant.updated = true
+            end
+        },
+        {
             text = _("Use book text for x-ray and recap"),
             checked_func = function () return assistant.settings:readSetting("use_book_text_for_analysis", false) end,
             callback = function()

--- a/assistant_utils.lua
+++ b/assistant_utils.lua
@@ -16,21 +16,21 @@ local socketutil = require("socketutil")
 local https = require("ssl.https")
 local json = require("rapidjson")
 local Trapper = require("ui/trapper")
+local Notebook = require("assistant_notebook")
 
 local M = {}
 local shared_buf = strbuf.new()
 
 function M.getGeneralNotebookFilePath(assistant)
-  local notebookfile = nil
-  local default_folder = util.tableGetValue(assistant.CONFIGURATION, "features", "default_folder_for_logs")
-  local home_dir = G_reader_settings:readSetting("home_dir")
-  local current_dir = assistant.ui.file_chooser and assistant.ui.file_chooser.path or assistant.ui:getLastDirFile()
-  local target_dir = default_folder and default_folder ~= "" and util.pathExists(default_folder) and default_folder or (home_dir or current_dir)
-  if target_dir then
-    local notebookfile_path = target_dir .. "/general_notebook.md"
-    notebookfile = notebookfile_path
+  if Notebook.isEnabled(assistant) then
+    local notebook, err, warning = Notebook.getActive(assistant)
+    if notebook then
+      return notebook.path, warning or err
+    end
+    return Notebook.getLegacyPath(assistant), warning or err
   end
-  return notebookfile
+
+  return Notebook.getLegacyPath(assistant)
 end
 
 function M.extractBookTextForAnalysis(CONFIGURATION, ui)
@@ -186,7 +186,7 @@ function M.getPageInfo(ui)
 end
 
 function M.saveToNotebookFile(assistant, log_entry)
-  local success, err = pcall(function()
+  local success, saved_path, save_err, used_fallback = pcall(function()
     local notebookfile = assistant.ui.bookinfo:getNotebookFile(assistant.ui.doc_settings)
     local default_folder = util.tableGetValue(assistant.CONFIGURATION, "features", "default_folder_for_logs")
     if assistant.ui.doc_settings then
@@ -234,28 +234,97 @@ function M.saveToNotebookFile(assistant, log_entry)
         assistant.ui.doc_settings:saveSetting("notebook_file", notebookfile)
       end
     else
-      notebookfile = M.getGeneralNotebookFilePath(assistant)
-    end
-
-    if notebookfile then
-      local file = io.open(notebookfile, "a")
-      if file then
-        file:write(log_entry)
-        file:close()
-      else
-        logger.warn("Assistant: Could not open notebook file:", notebookfile)
+      local general_warning
+      notebookfile, general_warning = M.getGeneralNotebookFilePath(assistant)
+      if general_warning then
+        logger.warn("Assistant: General notebook warning:", general_warning)
+        UIManager:show(InfoMessage:new{
+          icon = "notice-warning",
+          text = general_warning,
+          timeout = 5,
+        })
       end
     end
+
+    if not notebookfile then
+      return nil, _("Notebook path is unavailable."), false
+    end
+
+    local file, open_err = io.open(notebookfile, "a")
+    local fallback_used = false
+
+    -- Multi-notebook is optional. If the selected destination cannot be
+    -- opened for append, fall back to the legacy general_notebook.md so the
+    -- conversation is not lost.
+    if not file and not assistant.ui.doc_settings and Notebook.isEnabled(assistant) then
+      local failed_path = notebookfile
+      local legacy_path = Notebook.getLegacyPath(assistant)
+
+      if legacy_path and legacy_path ~= failed_path then
+        logger.warn(
+          "Assistant: Could not open general notebook:",
+          failed_path,
+          open_err,
+          "- falling back to:",
+          legacy_path
+        )
+
+        notebookfile = legacy_path
+        file, open_err = io.open(notebookfile, "a")
+        fallback_used = file ~= nil
+      end
+    end
+
+    if not file then
+      logger.warn("Assistant: Could not open notebook file:", notebookfile, open_err)
+      return nil, open_err or _("Could not open notebook file."), false
+    end
+
+    local write_ok, write_err = file:write(log_entry)
+    local close_ok, close_err = file:close()
+    if not write_ok then
+      logger.warn("Assistant: Could not write notebook file:", notebookfile, write_err)
+      return nil, write_err or _("Could not write notebook file."), false
+    end
+    if close_ok == nil then
+      logger.warn("Assistant: Could not close notebook file:", notebookfile, close_err)
+      return nil, close_err or _("Could not close notebook file."), false
+    end
+
+    if fallback_used then
+      UIManager:show(InfoMessage:new{
+        icon = "notice-warning",
+        text = T(
+          _("Could not save to the selected notebook.\nSaved to: %1"),
+          "general_notebook"
+        ),
+        timeout = 5,
+      })
+    end
+
+    return notebookfile, nil, fallback_used
   end)
 
   if not success then
-    logger.warn("Assistant: Error during notebook save:", err)
+    logger.warn("Assistant: Error during notebook save:", saved_path)
+    UIManager:show(InfoMessage:new{
+      icon = "notice-warning",
+      text = _("Notebook save failed. Continuing..."),
+      timeout = 3,
+    })
+    return nil, saved_path, false
+  end
+
+  -- Preserve book-mode behavior, but make general-mode failures visible.
+  if not saved_path and not assistant.ui.doc_settings then
     UIManager:show(InfoMessage:new{
       icon = "notice-warning",
       text = _("Notebook save failed. Continuing..."),
       timeout = 3,
     })
   end
+
+  return saved_path, save_err, used_fallback == true
 end
 
 function M.normalizeMarkdownHeadings(content, heading_offset, max_heading_level)

--- a/assistant_viewer.lua
+++ b/assistant_viewer.lua
@@ -36,6 +36,7 @@ local Screen = Device.screen
 local MD = require("assistant_mdparser")
 local Prompts = require("assistant_prompts")
 local ASUtils = require("assistant_utils")
+local Notebook = require("assistant_notebook")
 
 -- Inject scroll page method for ScrollHtmlWidget
 ScrollHtmlWidget.scrollToPage = function(self, page_num)
@@ -250,11 +251,18 @@ function ChatGPTViewer:init()
   
   active_chatgpt_viewer = self
 
+  local is_multi_general =
+      not self.assistant.ui.doc_settings and Notebook.isEnabled(self.assistant)
+  local notebook_subtitle = is_multi_general
+      and Notebook.getActiveDisplayName(self.assistant, 24)
+      or nil
+
   local titlebar = TitleBar:new {
     width = self.width,
     align = "left",
     with_bottom_line = true,
     title = "Assistant: " .. (self.title or ""),
+    subtitle = notebook_subtitle,
     title_face = self.title_face,
     title_multilines = self.title_multilines,
     title_shrink_font_to_fit = self.title_shrink_font_to_fit,
@@ -441,11 +449,38 @@ function ChatGPTViewer:init()
       table.insert(buttons[#buttons], #(buttons[#buttons]), add_note_button)
   end
 
-  -- Only add Save button if auto_save_to_notebook is disabled
+  -- Only add Save button if auto_save_to_notebook is disabled.
+  -- In general multi-notebook mode, let the user choose the destination at
+  -- save time; otherwise preserve the existing one-click Save behavior.
   if not self.assistant.settings:readSetting("auto_save_to_notebook", false) then
       local save_button = {
           text = _("Save"),
           callback = function()
+              if is_multi_general then
+                  Notebook.showPicker(self.assistant, {
+                      title = _("Save conversation to"),
+                      on_select = function(notebook)
+                          local saved_path, _save_err, used_fallback = self:saveToNotebook()
+
+                          if titlebar and titlebar.setSubTitle then
+                              titlebar:setSubTitle(
+                                  Notebook.getActiveDisplayName(self.assistant, 24)
+                              )
+                          end
+
+                          if saved_path and not used_fallback then
+                              local saved_name = saved_path:match("([^/\\]+)$") or saved_path
+                              saved_name = saved_name:gsub("%.md$", "")
+                              UIManager:show(InfoMessage:new{
+                                  text = T(_("Saved to: %1"), saved_name),
+                                  timeout = 2,
+                              })
+                          end
+                      end,
+                  })
+                  return
+              end
+
               self:saveToNotebook()
               UIManager:show(InfoMessage:new{
                   text = _("Conversation is saved to NoteBook"),
@@ -544,7 +579,7 @@ function ChatGPTViewer:saveToNotebook()
   
   local log_entry = string.format("# [%s]%s\n## %s\n\n%s\n\n", timestamp, page_info, title_text, text_to_log)
   
-  ASUtils.saveToNotebookFile(self.assistant, log_entry)
+  return ASUtils.saveToNotebookFile(self.assistant, log_entry)
 end
 
 function ChatGPTViewer:onCloseWidget()

--- a/configuration.sample.lua
+++ b/configuration.sample.lua
@@ -327,6 +327,7 @@ local CONFIGURATION = {
         ota_github_base = "https://github.com", -- GitHub proxy base URL for OTA updates
         ota_github_repo = "omer-faruq/assistant.koplugin", -- GitHub repository for OTA updates
         default_folder_for_logs = nil,         -- Set the default folder for auto saved logs, nil for the same folder as the book, ex: "/mnt/onboard/logs/" for Kobo , "/mnt/us/documents/logs/" for Kindle
+        general_notebooks_folder = nil,        -- Optional folder for general notebooks; nil uses a general_notebooks subfolder under default_folder_for_logs (or home_dir if unset)
         max_text_length_for_analysis = 100000, -- max text length to be used on xray-recap-book analyzes,
         max_page_size_for_analysis = 250,      -- maximum page size to be used on xray-recap-book analyzes (for page-based documents, ex: PDF)
 

--- a/main.lua
+++ b/main.lua
@@ -19,6 +19,7 @@ local ButtonDialog = require("ui/widget/buttondialog")
 local ffiutil = require("ffi/util")
 local ToolExecutor = require("assistant_tool_executor")
 local ASUtils = require("assistant_utils")
+local Notebook = require("assistant_notebook")
 
 local _ = require("assistant_gettext")
 local N_ = _.ngettext
@@ -159,10 +160,77 @@ function Assistant:addToMainMenu(menu_items)
                 end,
               },
               {
-                text = _("NoteBook (AI Conversation Log)"),
+                text_func = function ()
+                  if not self.ui.doc_settings and Notebook.isEnabled(self) then
+                    return T(
+                      _("NoteBook: %1"),
+                      Notebook.getActiveDisplayName(self, 24)
+                    )
+                  end
+                  return _("NoteBook (AI Conversation Log)")
+                end,
                 callback = function ()
-                  local notebookfile = self.ui.bookinfo:getNotebookFile(self.ui.doc_settings)
-                  UIManager:show(ConfirmBox:new{
+                  local is_general_mode = not self.ui.doc_settings
+                  local notebookfile
+
+                  if is_general_mode then
+                    notebookfile = ASUtils.getGeneralNotebookFilePath(self)
+                  else
+                    notebookfile = self.ui.bookinfo:getNotebookFile(self.ui.doc_settings)
+                  end
+
+                  local other_buttons = {}
+                  local notebook_dialog
+
+                  if is_general_mode and Notebook.isEnabled(self) then
+                    table.insert(other_buttons, {
+                      text = _("Switch"),
+                      callback = function ()
+                        Notebook.showPicker(self, {
+                          on_select = function ()
+                            -- Close the old details dialog because it still
+                            -- refers to the previously active notebook.
+                            if notebook_dialog then
+                              UIManager:close(notebook_dialog)
+                            end
+                          end,
+                        })
+                      end
+                    })
+                  end
+
+                  table.insert(other_buttons, {
+                    text = _("Delete"),
+                    callback = function ()
+                      UIManager:show(ConfirmBox:new{
+                        text = T(_("Delete file?\n%1\nThis operation is not reversible."), notebookfile),
+                        ok_text = _("Delete"),
+                        ok_callback = function ()
+                          local ok, err = koutil.removeFile(notebookfile)
+                          if not ok then
+                            UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
+                            return
+                          end
+                          if notebook_dialog then
+                            UIManager:close(notebook_dialog)
+                          end
+                        end
+                      })
+                    end
+                  })
+
+                  -- KOReader's ShowNotebookFile event edits the current book
+                  -- notebook. Do not expose it for a general notebook path.
+                  if not is_general_mode then
+                    table.insert(other_buttons, {
+                      text = _("Edit"),
+                      callback = function ()
+                        UIManager:broadcastEvent(Event:new("ShowNotebookFile"))
+                      end
+                    })
+                  end
+
+                  notebook_dialog = ConfirmBox:new{
                     icon = "appbar.pageview",
                     face = Font:getFace("smallinfofont"),
                     text = ASUtils.bold_format(
@@ -178,30 +246,9 @@ function Assistant:addToMainMenu(menu_items)
                       end
                       TextViewer.openFile(notebookfile)
                     end,
-                    other_buttons = {{
-                      {
-                        text = _("Delete"),
-                        callback = function ()
-                          UIManager:show(ConfirmBox:new{
-                            text = T(_("Delete file?\n%1\nThis operation is not reversible."), notebookfile),
-                            ok_text = _("Delete"),
-                            ok_callback = function ()
-                              local ok, err = koutil.removeFile(notebookfile)
-                              if not ok then
-                                UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
-                              end
-                            end
-                          })
-                        end
-                      },
-                      {
-                        text = _("Edit"),
-                        callback = function ()
-                          UIManager:broadcastEvent(Event:new("ShowNotebookFile"))
-                        end
-                      },
-                    }}
-                  })
+                    other_buttons = { other_buttons },
+                  }
+                  UIManager:show(notebook_dialog)
                 end,
                 separator = true,
               },


### PR DESCRIPTION
## Summary

Adds support for multiple general notebooks while keeping the existing book-specific notebook behavior unchanged.

## Changes

- Add a `general_notebooks/` folder for general AI conversations.
- Allow creating and switching between multiple Markdown notebooks.
- Keep the selected general notebook active across sessions.
- Show the active notebook in the Ask dialog, viewer, Quick Notes, and NoteBook menu.
- Support an optional `general_notebooks_folder` configuration.
- Discover existing `.md` files placed manually in the notebooks folder.
- Preserve the existing `general_notebook.md` as a legacy option.
- Fall back to `general_notebook.md` if the selected notebook cannot be written.
- Add filename validation for FAT-compatible filesystems.

## Behavior

- Multiple general notebooks are disabled by default.
- With the feature disabled, existing behavior is unchanged.
- With multiple notebooks enabled:
  - Auto-save ON: conversations are silently appended to the active notebook.
  - Auto-save OFF: the Save button opens the notebook picker.
  - Quick Notes are saved directly to the active notebook.
- Book-specific notebooks remain unchanged.

## Testing

Tested on KOReader 2026.07.2 (Kobo Clara HD) with:

- Legacy single-notebook mode.
- Multiple notebook creation and switching.
- Active notebook persistence after restart.
- Manual `.md` file discovery.
- Custom notebook folder and invalid-folder fallback.
- Write failure fallback to `general_notebook.md`.
- Filename validation, including FAT/Windows reserved names.
- Quick Notes and AI conversation saving.
- Book-mode regression.

## Screenshots

<img width="1072" height="1448" alt="FileManager_2026-08-13_122914" src="https://github.com/user-attachments/assets/1ccece03-308d-45c9-8835-0e07a4f39800" />

<img width="1072" height="1448" alt="FileManager_2026-08-13_122943" src="https://github.com/user-attachments/assets/22a4b022-3bee-49c7-9bc7-c56f3ace0b1a" />

<img width="1072" height="1448" alt="FileManager_2026-08-13_122924" src="https://github.com/user-attachments/assets/3090cb02-fcbf-4453-b71b-59c655ccef82" />

<img width="1072" height="1448" alt="FileManager_2026-08-13_123013" src="https://github.com/user-attachments/assets/274d495b-6fac-4544-9b8b-3f24b10bd4e6" />