### PR TITLE
Fix ~20s delay before Wi-Fi prompt on every AI action

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -32,6 +32,20 @@ local showDictionaryDialog = require("assistant_dictdialog")
 local Registry = require("assistant_provider_registry")
 local SearchRegistry = require("assistant_search_registry")
 
+--- Like NetworkMgr:runWhenOnline(), but checks Wi-Fi radio state first.
+-- NetworkMgr:runWhenOnline() calls isOnline(), which does a real DNS
+-- resolution and can take up to ~20s to time out before falling back to
+-- the "Do you want to turn on Wi-Fi?" prompt. When Wi-Fi is already off,
+-- isWifiOn() is an instant local check that reaches the same prompt
+-- without waiting on the network first.
+local function runWhenOnlineFast(callback)
+  if not NetworkMgr:isWifiOn() then
+    NetworkMgr:promptWifiOn(callback)
+    return
+  end
+  NetworkMgr:runWhenOnline(callback)
+end
+
 local Assistant = InputContainer:new {
   name = "assistant",
   meta = nil,           -- reference to the _meta module
@@ -471,7 +485,7 @@ function BookLevelCustomPrompts(assistant)
           Prompts.isWebSearchEnabled(assistant.settings)),
         callback = function()
           if not assistant:isConfigured() then return end
-          NetworkMgr:runWhenOnline(function()
+          runWhenOnlineFast(function()
             local book = getDocumentInfo(assistant.ui.document)
             local showFeatureDialog = require("assistant_featuredialog")
             Trapper:wrap(function()
@@ -684,7 +698,7 @@ function Assistant:_showAddProviderDialog(preset_name, handler, base_url, additi
                     -- auth headers and post-processing itself, and runs the
                     -- request behind a dismissable InfoMessage so a stalled
                     -- network can be cancelled by tapping.
-                    NetworkMgr:runWhenOnline(function()
+                    runWhenOnlineFast(function()
                         Trapper:wrap(function()
                             local mp = require("assistant_model_picker")
                             local model_list, err = mp.fetchModels(handler, url, api_key)
@@ -1009,7 +1023,7 @@ function Assistant:init()
             return
           end
 
-          NetworkMgr:runWhenOnline(function()
+          runWhenOnlineFast(function()
             if not updateMessageShown then
               Updater.checkForUpdates(self)
               updateMessageShown = true
@@ -1189,7 +1203,7 @@ function Assistant:addMainButton(prompt_idx, prompt)
             self.quicknote:saveNote(nil, _reader_highlight_instance.selected_text.text)
           end)
         else
-          NetworkMgr:runWhenOnline(function()
+          runWhenOnlineFast(function()
             Trapper:wrap(function()
               if prompt.order == -10 and prompt_idx == "dictionary" then
                 -- Dictionary prompt, show dictionary dialog
@@ -1271,7 +1285,7 @@ function Assistant:_buildAssistantDictButtons(dict_popup_arg, live)
     callback = function(widget_instance)
         local popup = widget_instance or dict_popup_arg
         local word = popup and popup.word
-        NetworkMgr:runWhenOnline(function()
+        runWhenOnlineFast(function()
             Trapper:wrap(function()
               self.assistant_dialog:showPrompt(word, "wikipedia")
             end)
@@ -1290,7 +1304,7 @@ function Assistant:_buildAssistantDictButtons(dict_popup_arg, live)
     callback = function(widget_instance)
         local popup = widget_instance or dict_popup_arg
         local word = popup and popup.word
-        NetworkMgr:runWhenOnline(function()
+        runWhenOnlineFast(function()
             Trapper:wrap(function()
               showDictionaryDialog(self, word, nil, "term_xray")
             end)
@@ -1305,7 +1319,7 @@ function Assistant:_buildAssistantDictButtons(dict_popup_arg, live)
     callback = function(widget_instance)
         local popup = widget_instance or dict_popup_arg
         local word = popup and popup.word
-        NetworkMgr:runWhenOnline(function()
+        runWhenOnlineFast(function()
             Trapper:wrap(function()
               showDictionaryDialog(self, word)
             end)
@@ -1344,7 +1358,7 @@ function Assistant:_buildAssistantDictButtons(dict_popup_arg, live)
         callback = function(widget_instance)
             local popup = widget_instance or dict_popup_arg
             local word = popup and popup.word
-            NetworkMgr:runWhenOnline(function()
+            runWhenOnlineFast(function()
                 Trapper:wrap(function()
                   self.assistant_dialog:showPrompt(word, prompt.id)
                 end)
@@ -1475,7 +1489,7 @@ end
       return
     end
     
-    NetworkMgr:runWhenOnline(function()
+    runWhenOnlineFast(function()
       -- Show dialog without highlighted text
       Trapper:wrap(function()
         self.assistant_dialog:show()
@@ -1486,7 +1500,7 @@ end
 
   function Assistant:onAskAIRecap()
     if not self:isConfigured() then return end
-    NetworkMgr:runWhenOnline(function()
+    runWhenOnlineFast(function()
       local book = getDocumentInfo(self.ui.document)
       local showFeatureDialog = require("assistant_featuredialog")
       Trapper:wrap(function()
@@ -1498,7 +1512,7 @@ end
 
   function Assistant:onAskAIXRay()
     if not self:isConfigured() then return end
-    NetworkMgr:runWhenOnline(function()
+    runWhenOnlineFast(function()
       local book = getDocumentInfo(self.ui.document)
       local showFeatureDialog = require("assistant_featuredialog")
       Trapper:wrap(function()
@@ -1510,7 +1524,7 @@ end
 
   function Assistant:onAskAIBookInfo()
     if not self:isConfigured() then return end
-    NetworkMgr:runWhenOnline(function()
+    runWhenOnlineFast(function()
       local book = getDocumentInfo(self.ui.document)
       local showFeatureDialog = require("assistant_featuredialog")
       Trapper:wrap(function()
@@ -1522,7 +1536,7 @@ end
 
   function Assistant:onAskAIAnnotations()
     if not self:isConfigured() then return end
-    NetworkMgr:runWhenOnline(function()
+    runWhenOnlineFast(function()
       local book = getDocumentInfo(self.ui.document)
       local showFeatureDialog = require("assistant_featuredialog")
       Trapper:wrap(function()
@@ -1534,7 +1548,7 @@ end
 
   function Assistant:onAskSummaryUsingAnnotations()
     if not self:isConfigured() then return end
-    NetworkMgr:runWhenOnline(function()
+    runWhenOnlineFast(function()
       local book = getDocumentInfo(self.ui.document)
       local showFeatureDialog = require("assistant_featuredialog")
       Trapper:wrap(function()
@@ -1578,7 +1592,7 @@ function Assistant:syncTranslateOverride()
       end
 
       local words = koutil.splitToWords(text)
-      NetworkMgr:runWhenOnline(function()
+      runWhenOnlineFast(function()
         Trapper:wrap(function()
           -- splitToWords result like this: { "The", " ", "good", " ", "news" }
           if #words > 5 then
@@ -1684,7 +1698,7 @@ function Assistant:_hookRecap()
             text            = message,
             ok_text         = _("Yes"),
             ok_callback     = function()
-              NetworkMgr:runWhenOnline(function()
+              runWhenOnlineFast(function()
                 local showFeatureDialog = require("assistant_featuredialog")
                 Trapper:wrap(function()
                   showFeatureDialog(assistant, "recap", title, authors, percent_finished)


### PR DESCRIPTION
Fixes the delay reported in https://github.com/omer-faruq/assistant.koplugin/discussions/196 .

NetworkMgr:runWhenOnline() calls isOnline() first, which performs a real DNS resolution and can take up to ~20s to time out before falling back to the 'Do you want to turn on Wi-Fi?' prompt. With Wi-Fi off, every network-triggering action in the plugin (Wikipedia, Dictionary, Recap, Term X-Ray, the highlight-menu AI Assistant button, translate override, etc. - 16 call sites) appears to hang silently for ~20s before the prompt shows up.

## Fix

Adds a unWhenOnlineFast() wrapper that checks NetworkMgr:isWifiOn() first - an instant local radio-state check, no network round-trip. If Wi-Fi is off, it jumps straight to the same prompt unWhenOnline() eventually shows anyway, just without the DNS wait. If Wi-Fi is on, it defers to the normal unWhenOnline()/isOnline() check, since that's still needed to verify actual connectivity (Wi-Fi on doesn't guarantee internet access).

All 16 existing NetworkMgr:runWhenOnline(...) call sites now go through this wrapper instead.

## Testing

Verified with loadfile() for syntax correctness, and deployed live on a Kindle Paperwhite 5 running KOReader v2026.07.2 - confirmed the Wi-Fi prompt now appears immediately when Wi-Fi is off, and normal online behavior is unaffected when Wi-Fi is on.